### PR TITLE
Add dependency information in project descriptor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,8 @@ apply plugin: 'org.jetbrains.intellij'
 apply plugin: 'java'
 
 intellij {
-    version 'IC-2016.2'
-    plugins 'gradle', 'maven'
+    version 'IC-2018.1'
+    plugins 'gradle', 'maven', 'groovy'
     pluginName 'JFrog'
     updateSinceUntilBuild = false
 }

--- a/src/main/java/com/jfrog/ide/idea/NpmProject.java
+++ b/src/main/java/com/jfrog/ide/idea/NpmProject.java
@@ -11,6 +11,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.picocontainer.PicoContainer;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 /**
  * Unlike maven or gradle, for npm, there there's no real project in IntelliJ. We therefore use this project.
  *
@@ -19,16 +22,23 @@ import org.picocontainer.PicoContainer;
 @SuppressWarnings("ConstantConditions")
 public class NpmProject implements Project {
 
-    private String bashPath;
+    private String basePath;
+    private VirtualFile virtualFile;
 
-    public NpmProject(String bashPath) {
-        this.bashPath = bashPath;
+    public NpmProject(String basePath) {
+        this.basePath = basePath;
+    }
+
+    public NpmProject(VirtualFile baseDir, String basePath) {
+        this(basePath);
+        Path packageJsonPath = Paths.get(baseDir.getPath()).relativize(Paths.get(basePath, "package.json"));
+        this.virtualFile = baseDir.findFileByRelativePath(packageJsonPath.toString());
     }
 
     @NotNull
     @Override
     public String getName() {
-        return bashPath;
+        return basePath;
     }
 
     @Override
@@ -39,13 +49,13 @@ public class NpmProject implements Project {
     @Nullable
     @Override
     public String getBasePath() {
-        return bashPath;
+        return basePath;
     }
 
     @Nullable
     @Override
     public VirtualFile getProjectFile() {
-        return null;
+        return virtualFile;
     }
 
     @Nullable

--- a/src/main/java/com/jfrog/ide/idea/inspections/AbstractInspection.java
+++ b/src/main/java/com/jfrog/ide/idea/inspections/AbstractInspection.java
@@ -1,0 +1,225 @@
+package com.jfrog.ide.idea.inspections;
+
+import com.intellij.codeInspection.LocalInspectionTool;
+import com.intellij.codeInspection.ProblemsHolder;
+import com.intellij.lang.annotation.AnnotationHolder;
+import com.intellij.lang.annotation.Annotator;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.wm.ToolWindow;
+import com.intellij.openapi.wm.ToolWindowManager;
+import com.intellij.psi.PsiElement;
+import com.jfrog.ide.idea.scan.ScanManager;
+import com.jfrog.ide.idea.ui.issues.IssuesTree;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.jfrog.build.extractor.scan.DependenciesTree;
+import org.jfrog.build.extractor.scan.GeneralInfo;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Parent class of all inspections and annotations.
+ * The inspection are the "Show in dependencies tree" action.
+ * The annotations are the "Top issue" and "Licenses" labels.
+ *
+ * @author yahavi
+ */
+public abstract class AbstractInspection extends LocalInspectionTool implements Annotator {
+
+    private String packageDescriptorName;
+
+    AbstractInspection(String packageDescriptorName) {
+        this.packageDescriptorName = packageDescriptorName;
+    }
+
+    /**
+     * Get Psi element and decide whether to add "Show in dependencies tree" option.
+     *
+     * @param problemsHolder - The "Show in dependencies tree" option will be registered in this container.
+     * @param element        - The Psi element in the package descriptor
+     */
+    void visitElement(ProblemsHolder problemsHolder, PsiElement element) {
+        List<DependenciesTree> dependencies = getDependencies(element);
+        if (CollectionUtils.isNotEmpty(dependencies)) {
+            InspectionUtils.registerProblem(problemsHolder, dependencies, getTargetElements(element));
+        }
+    }
+
+    /**
+     * Get Psi element and decide whether to add licenses and top issue annotations.
+     *
+     * @param annotationHolder - The annotations will be registered in this container
+     * @param element          - The Psi element in the package descriptor
+     */
+    void visitElement(AnnotationHolder annotationHolder, PsiElement element) {
+        List<DependenciesTree> dependencies = getDependencies(element);
+        if (CollectionUtils.isNotEmpty(dependencies)) {
+            AnnotationUtils.registerAnnotation(annotationHolder, dependencies.get(0), getTargetElements(element));
+        }
+    }
+
+    /**
+     * Get the elements to apply the inspections and annotations.
+     *
+     * @param element - The Psi element in the package descriptor
+     * @return elements array to apply the inspection and annotation
+     */
+    abstract PsiElement[] getTargetElements(PsiElement element);
+
+    /**
+     * Get the relevant scan manager according to the project type and path.
+     *
+     * @param project - The Project
+     * @param path    - Path to project
+     * @return ScanManager
+     */
+    abstract ScanManager getScanManager(Project project, String path);
+
+    /**
+     * Return true iff the Psi element is a dependency.
+     *
+     * @param element - The Psi element in the package descriptor.
+     * @return true iff the Psi element is a dependency
+     */
+    abstract boolean isDependency(PsiElement element);
+
+    /**
+     * Create general info from the Psi element. Called when isDependency(element) == true.
+     *
+     * @param element - The Psi element in the package descriptor
+     * @return GeneralInfo
+     */
+    abstract GeneralInfo createGeneralInfo(PsiElement element);
+
+    /**
+     * Get the submodules containing the dependency in the Psi element. The result depends on the root project structure:
+     * In case of dependency selected:
+     * Single project, single module - Return the root project.
+     * Single project, multi module - Return the module contains the dependency.
+     * Multi project - Return the module containing the dependency within the projects.
+     *
+     * @param element     - The Psi element in the package descriptor
+     * @param generalInfo - The general info of the dependency
+     * @return Set of modules containing the dependency or null if not found
+     */
+    abstract Set<DependenciesTree> getModules(PsiElement element, GeneralInfo generalInfo);
+
+    /**
+     * Determine whether to apply the inspection on the Psi element.
+     *
+     * @param element - The Psi element in the package descriptor
+     * @return true iff the element is a dependency and the plugin is ready to show inspection for it
+     */
+    boolean isShowInspection(PsiElement element) {
+        Project project = element.getProject();
+
+        ToolWindow toolWindow = ToolWindowManager.getInstance(project).getToolWindow("JFrog");
+        if (toolWindow == null) {
+            return false; // Tool window not yet activated
+        }
+
+        VirtualFile editorFile = element.getContainingFile().getVirtualFile();
+        if (!editorFile.getPath().endsWith(packageDescriptorName)) {
+            return false; // File is not a package descriptor file
+        }
+
+        ScanManager scanManager = getScanManager(project, editorFile.getParent().getPath());
+        if (scanManager == null) {
+            return false; // Scan manager for this project not yet created
+        }
+        return isDependency(element);
+    }
+
+    /**
+     * Get all dependencies in the dependencies tree that relevant to the element.
+     *
+     * @param element - The Psi element in the package descriptor
+     * @return all dependencies in the dependencies tree that relevant to the element
+     */
+    List<DependenciesTree> getDependencies(PsiElement element) {
+        if (!isShowInspection(element)) {
+            return null; // Inspection is not needed for this element
+        }
+        GeneralInfo generalInfo = createGeneralInfo(element);
+        if (generalInfo == null) {
+            return null; // Creating the general info failed
+        }
+        Set<DependenciesTree> modules = getModules(element, generalInfo);
+        if (modules == null) {
+            return null; // No modules found for this element
+        }
+        return modules.stream()
+                .map(module -> getModuleDependency(module, generalInfo))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Get the module dependency that match to the input general info.
+     *
+     * @param module      - The dependencies tree module
+     * @param generalInfo - The general info
+     * @return module dependencies that match to the input general info
+     */
+    private DependenciesTree getModuleDependency(DependenciesTree module, GeneralInfo generalInfo) {
+        for (DependenciesTree dependency : module.getChildren()) {
+            GeneralInfo childGeneralInfo = dependency.getGeneralInfo();
+            if (childGeneralInfo == null) {
+                childGeneralInfo = new GeneralInfo().componentId(dependency.getUserObject().toString());
+            }
+            if (compareGeneralInfos(generalInfo, childGeneralInfo)) {
+                return dependency;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Search the node of the project in the dependencies tree. If this is a single project, return the root.
+     *
+     * @param root    - The root of the dependencies tree
+     * @param project - The project
+     * @return the node of the project in the dependencies tree
+     */
+    DependenciesTree getProjectNode(DependenciesTree root, Project project) {
+        if (root.getGeneralInfo() != null) {
+            return root;
+        }
+        return root.getChildren().stream()
+                .filter(child -> StringUtils.equals((String) child.getUserObject(), project.getName()))
+                .findAny()
+                .orElse(root);
+    }
+
+    /**
+     * Get the root of the dependencies tree of the input project.
+     *
+     * @param element - The Psi element in the package descriptor
+     * @return root of the dependencies tree of the input project
+     */
+    DependenciesTree getRootDependenciesTree(PsiElement element) {
+        Project project = element.getProject();
+        IssuesTree issuesTree = IssuesTree.getInstance(project);
+        if (issuesTree == null || issuesTree.getModel() == null) {
+            return null;
+        }
+        return (DependenciesTree) issuesTree.getModel().getRoot();
+    }
+
+    /**
+     * Compare between the generated general info from the Psi element and the build info from the Dependencies tree.
+     * If groupId is empty, compare only artifactId.
+     *
+     * @param generatedGeneralInfo - General info generated for the selected Psi element in the package descriptor
+     * @param generalInfo          - General info from the dependencies tree
+     * @return true iff 2 general infos considered equal
+     */
+    boolean compareGeneralInfos(GeneralInfo generatedGeneralInfo, GeneralInfo generalInfo) {
+        return StringUtils.equals(generatedGeneralInfo.getArtifactId(), generalInfo.getArtifactId()) &&
+                StringUtils.equalsAny(generatedGeneralInfo.getGroupId(), generalInfo.getGroupId(), "");
+    }
+}

--- a/src/main/java/com/jfrog/ide/idea/inspections/AbstractInspection.java
+++ b/src/main/java/com/jfrog/ide/idea/inspections/AbstractInspection.java
@@ -23,7 +23,7 @@ import java.util.stream.Collectors;
 
 /**
  * Parent class of all inspections and annotations.
- * The inspection are the "Show in dependencies tree" action.
+ * The inspections are the "Show in dependencies tree" action.
  * The annotations are the "Top issue" and "Licenses" labels.
  *
  * @author yahavi
@@ -159,7 +159,7 @@ public abstract class AbstractInspection extends LocalInspectionTool implements 
     }
 
     /**
-     * Get the module dependency that match to the input general info.
+     * Get the module dependency that matches to the input general info.
      *
      * @param module      - The dependencies tree module
      * @param generalInfo - The general info
@@ -179,7 +179,7 @@ public abstract class AbstractInspection extends LocalInspectionTool implements 
     }
 
     /**
-     * Search the node of the project in the dependencies tree. If this is a single project, return the root.
+     * Search for the node of the project in the dependencies tree. If this is a single project, return the root.
      *
      * @param root    - The root of the dependencies tree
      * @param project - The project
@@ -211,7 +211,7 @@ public abstract class AbstractInspection extends LocalInspectionTool implements 
     }
 
     /**
-     * Compare between the generated general info from the Psi element and the build info from the Dependencies tree.
+     * Compare the generated general info from the Psi element and the build info from the Dependencies tree.
      * If groupId is empty, compare only artifactId.
      *
      * @param generatedGeneralInfo - General info generated for the selected Psi element in the package descriptor

--- a/src/main/java/com/jfrog/ide/idea/inspections/AnnotationUtils.java
+++ b/src/main/java/com/jfrog/ide/idea/inspections/AnnotationUtils.java
@@ -1,0 +1,92 @@
+package com.jfrog.ide.idea.inspections;
+
+import com.intellij.lang.annotation.AnnotationHolder;
+import com.intellij.lang.annotation.HighlightSeverity;
+import com.intellij.psi.PsiElement;
+import org.jfrog.build.extractor.scan.DependenciesTree;
+import org.jfrog.build.extractor.scan.Issue;
+import org.jfrog.build.extractor.scan.License;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * @author yahavi
+ */
+public class AnnotationUtils {
+
+    private final static Issue NORMAL_SEVERITY_ISSUE = new Issue();
+
+    /**
+     * Register "Top issue" and "Licenses" annotations.
+     *
+     * @param annotationHolder - The annotations will be registered in this container
+     * @param dependency       - The dependencies tree node correlated to the element
+     * @param elements         - The elements to apply the annotations.
+     */
+    static void registerAnnotation(AnnotationHolder annotationHolder, DependenciesTree dependency, PsiElement[] elements) {
+        HighlightSeverity problemHighlightType = getHighlightSeverity(dependency);
+        String licensesString = getLicensesString(dependency);
+        String topIssue = getTopIssueString(dependency);
+        Arrays.stream(elements)
+                .filter(Objects::nonNull)
+                .map(PsiElement::getTextRange)
+                .forEach(textRange -> {
+                    annotationHolder.createAnnotation(problemHighlightType, textRange, topIssue);
+                    annotationHolder.createAnnotation(problemHighlightType, textRange, licensesString);
+                });
+    }
+
+    /**
+     * Get the severity of the dependencies tree node.
+     *
+     * @param node - The dependencies tree node
+     * @return the severity of the dependencies tree node
+     */
+    private static HighlightSeverity getHighlightSeverity(DependenciesTree node) {
+        switch (node.getTopIssue().getSeverity()) {
+            case High:
+            case Critical:
+                return HighlightSeverity.ERROR; // Red underline
+            case Low:
+                //noinspection deprecation
+            case Minor:
+            case Medium:
+            case Major:
+                return HighlightSeverity.WEAK_WARNING; // White underline
+            default: // Normal, information, unknown and pending
+                return HighlightSeverity.INFORMATION; // No underline
+        }
+    }
+
+    /**
+     * Get the top issue string.
+     *
+     * @param node - The dependencies tree node
+     * @return the top issue string
+     */
+    private static String getTopIssueString(DependenciesTree node) {
+        Issue topIssue = node.getTopIssue();
+        if (topIssue.isHigherSeverityThan(NORMAL_SEVERITY_ISSUE)) {
+            return "Top issue severity: " + topIssue.getSeverity();
+        }
+        return "No issues found";
+    }
+
+    /**
+     * Get licenses string
+     *
+     * @param node - The dependencies tree node
+     * @return licenses string
+     */
+    private static String getLicensesString(DependenciesTree node) {
+        String results = "Licenses: ";
+        List<String> licensesStrings = node.getLicenses().stream().map(License::getName).collect(Collectors.toList());
+        if (licensesStrings.isEmpty()) {
+            return results + "Unknown";
+        }
+        return results + String.join(", ", licensesStrings);
+    }
+}

--- a/src/main/java/com/jfrog/ide/idea/inspections/GradleInspection.java
+++ b/src/main/java/com/jfrog/ide/idea/inspections/GradleInspection.java
@@ -1,0 +1,220 @@
+package com.jfrog.ide.idea.inspections;
+
+import com.google.common.collect.Sets;
+import com.intellij.codeInspection.ProblemsHolder;
+import com.intellij.lang.annotation.AnnotationHolder;
+import com.intellij.openapi.externalSystem.settings.ExternalProjectSettings;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.PsiType;
+import com.jfrog.ide.idea.scan.GradleScanManager;
+import com.jfrog.ide.idea.scan.ScanManager;
+import com.jfrog.ide.idea.scan.ScanManagersFactory;
+import com.jfrog.ide.idea.utils.Utils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.plugins.gradle.settings.GradleSettings;
+import org.jetbrains.plugins.groovy.lang.psi.GroovyElementVisitor;
+import org.jetbrains.plugins.groovy.lang.psi.GroovyPsiElementVisitor;
+import org.jetbrains.plugins.groovy.lang.psi.api.statements.arguments.GrNamedArgument;
+import org.jetbrains.plugins.groovy.lang.psi.api.statements.expressions.GrExpression;
+import org.jetbrains.plugins.groovy.lang.psi.api.statements.expressions.literals.GrLiteral;
+import org.jetbrains.plugins.groovy.lang.psi.api.util.GrNamedArgumentsOwner;
+import org.jfrog.build.extractor.scan.DependenciesTree;
+import org.jfrog.build.extractor.scan.GeneralInfo;
+
+import javax.swing.tree.DefaultMutableTreeNode;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * @author yahavi
+ */
+@SuppressWarnings("InspectionDescriptionNotFoundInspection")
+public class GradleInspection extends AbstractInspection {
+
+    public static final String GRADLE_VERSION_KEY = "version";
+    public static final String GRADLE_GROUP_KEY = "group";
+    public static final String GRADLE_NAME_KEY = "name";
+
+    public GradleInspection() {
+        super("build.gradle");
+    }
+
+    @NotNull
+    @Override
+    public PsiElementVisitor buildVisitor(@NotNull final ProblemsHolder holder, boolean isOnTheFly) {
+        return new GroovyPsiElementVisitor(new GroovyElementVisitor() {
+            @Override
+            public void visitLiteralExpression(@NotNull GrLiteral literal) {
+                super.visitLiteralExpression(literal);
+                GradleInspection.this.visitElement(holder, literal);
+            }
+        });
+    }
+
+    @Override
+    public void annotate(@NotNull PsiElement element, @NotNull AnnotationHolder holder) {
+        if (element instanceof GrLiteral) {
+            GradleInspection.this.visitElement(holder, element);
+        }
+    }
+
+    @Override
+    PsiElement[] getTargetElements(PsiElement element) {
+        if (element.getParent() instanceof GrNamedArgument) {
+            return new PsiElement[]{element.getParent()};
+        }
+        return new PsiElement[]{element};
+    }
+
+    @Override
+    ScanManager getScanManager(Project project, String path) {
+        return ScanManagersFactory.getScanManagers(project).stream()
+                .filter(GradleScanManager.class::isInstance)
+                .findAny()
+                .orElse(null);
+    }
+
+    @Override
+    boolean isDependency(PsiElement element) {
+        PsiElement parent = element.getParent();
+        for (int i = 0; i < 4; i++, parent = parent.getParent()) {
+            if (parent instanceof GrExpression) {
+                PsiType type = ((GrExpression) parent).getType();
+                if (type != null && "Dependency".equals(type.getPresentableText())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    GeneralInfo createGeneralInfo(PsiElement element) {
+        PsiElement parent = element.getParent();
+        if (parent instanceof GrNamedArgument) {
+            GrNamedArgumentsOwner namedArgument = (GrNamedArgumentsOwner) parent.getParent();
+            return new GeneralInfo()
+                    .groupId(extractExpresion(namedArgument, GRADLE_GROUP_KEY))
+                    .artifactId(extractExpresion(namedArgument, GRADLE_NAME_KEY))
+                    .version(extractExpresion(namedArgument, GRADLE_VERSION_KEY));
+        }
+        String componentId = getLiteralValue((GrLiteral) element);
+        if (componentId.startsWith(":")) { // compile project(':xyz')
+            componentId = componentId + ":";
+        }
+        return new GeneralInfo().componentId(componentId);
+    }
+
+    @Override
+    Set<DependenciesTree> getModules(PsiElement element, GeneralInfo generalInfo) {
+        Project project = element.getProject();
+        DependenciesTree root = getRootDependenciesTree(element);
+        List<String> gradleModules = getGradleModules(project);
+        if (root == null || gradleModules == null) {
+            return null;
+        }
+
+        // Single project, single module
+        if (gradleModules.size() <= 1 && root.getGeneralInfo() != null) {
+            return Sets.newHashSet(root);
+        }
+
+        // Multi project
+        root = getProjectNode(root, project);
+
+        // Multi module
+        if (isModule(root, generalInfo)) {
+            return Sets.newHashSet(root);
+        }
+
+        // Collect the modules containing the dependency
+        return collectModules(root, generalInfo);
+    }
+
+    /**
+     * Get all modules of the current project
+     *
+     * @param project - The current project
+     * @return list of gradle modules or null if the Gradle project not yet initialized
+     */
+    private List<String> getGradleModules(Project project) {
+        GradleSettings.MyState gradleState = GradleSettings.getInstance(project).getState();
+        if (gradleState == null) {
+            return null;
+        }
+        return gradleState.getLinkedExternalProjectsSettings().stream()
+                .map(ExternalProjectSettings::getModules)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Return true iff the dependency stated in the General info is a module in the project.
+     *
+     * @param node        - The project node
+     * @param generalInfo - General info of the dependency
+     * @return true iff the dependency stated in the General info is a module in the project
+     */
+    private boolean isModule(DependenciesTree node, GeneralInfo generalInfo) {
+        return node.getChildren().stream()
+                .map(DefaultMutableTreeNode::getUserObject)
+                .filter(Objects::nonNull)
+                .map(Object::toString)
+                .anyMatch(name -> name.equals(generalInfo.getArtifactId()));
+    }
+
+    /**
+     * Collect all modules containing the dependency stated in the general info.
+     *
+     * @param node        - The project node
+     * @param generalInfo - General info of the dependency
+     * @return list of all nodes of the Gradle modules
+     */
+    private Set<DependenciesTree> collectModules(DependenciesTree node, GeneralInfo generalInfo) {
+        Set<DependenciesTree> modules = Sets.newHashSet();
+        node.getChildren().forEach(child -> child.getChildren().stream()
+                .map(DependenciesTree::getGeneralInfo)
+                .filter(Objects::nonNull)
+                .filter(grandChildGeneralInfo -> Utils.gavStringEqual(grandChildGeneralInfo, generalInfo))
+                .findAny()
+                .ifPresent(grandChildGeneralInfo -> modules.add(child)));
+        return modules;
+    }
+
+    /**
+     * Extract expression from groovy arguments.
+     *
+     * @param argumentList - The arguments list
+     * @param name         - The name of the argument to extract
+     * @return the value of the argument
+     */
+    private String extractExpresion(GrNamedArgumentsOwner argumentList, String name) {
+        GrNamedArgument argument = argumentList.findNamedArgument(name);
+        if (argument == null) {
+            return "";
+        }
+        GrExpression grExpression = argument.getExpression();
+        if (grExpression == null) {
+            return "";
+        }
+        if (!(grExpression instanceof GrLiteral)) {
+            return "";
+        }
+        return getLiteralValue((GrLiteral) grExpression);
+    }
+
+    /**
+     * Get the string value of the groovy literal.
+     *
+     * @param literal - The groovy literal
+     * @return the value of the literal
+     */
+    private String getLiteralValue(GrLiteral literal) {
+        return Objects.toString((literal).getValue(), "");
+    }
+}

--- a/src/main/java/com/jfrog/ide/idea/inspections/GradleInspection.java
+++ b/src/main/java/com/jfrog/ide/idea/inspections/GradleInspection.java
@@ -7,11 +7,11 @@ import com.intellij.openapi.externalSystem.settings.ExternalProjectSettings;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
-import com.intellij.psi.PsiType;
 import com.jfrog.ide.idea.scan.GradleScanManager;
 import com.jfrog.ide.idea.scan.ScanManager;
 import com.jfrog.ide.idea.scan.ScanManagersFactory;
 import com.jfrog.ide.idea.utils.Utils;
+import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.plugins.gradle.settings.GradleSettings;
 import org.jetbrains.plugins.groovy.lang.psi.GroovyElementVisitor;
@@ -82,12 +82,9 @@ public class GradleInspection extends AbstractInspection {
     @Override
     boolean isDependency(PsiElement element) {
         PsiElement parent = element.getParent();
-        for (int i = 0; i < 4; i++, parent = parent.getParent()) {
-            if (parent instanceof GrExpression) {
-                PsiType type = ((GrExpression) parent).getType();
-                if (type != null && "Dependency".equals(type.getPresentableText())) {
-                    return true;
-                }
+        for (int i = 0; i < 6; i++, parent = parent.getParent()) {
+            if (StringUtils.startsWith(parent.getText(), "dependencies")) {
+                return true;
             }
         }
         return false;

--- a/src/main/java/com/jfrog/ide/idea/inspections/InspectionUtils.java
+++ b/src/main/java/com/jfrog/ide/idea/inspections/InspectionUtils.java
@@ -1,0 +1,49 @@
+package com.jfrog.ide.idea.inspections;
+
+import com.intellij.codeInspection.ProblemHighlightType;
+import com.intellij.codeInspection.ProblemsHolder;
+import com.intellij.psi.PsiElement;
+import org.jfrog.build.extractor.scan.DependenciesTree;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * @author yahavi
+ */
+public class InspectionUtils {
+
+    final static String SHOW_IN_DEPENDENCIES_TREE = "Show in dependencies tree";
+
+    /**
+     * Register "Top issue" and "Licenses" annotations.
+     *
+     * @param problemsHolder - The "Show in dependencies tree" quickfix will be registered in this container
+     * @param dependencies   - The dependencies tree nodes correlated to the element
+     * @param elements       - The elements to apply the annotations.
+     */
+    static void registerProblem(ProblemsHolder problemsHolder, List<DependenciesTree> dependencies, PsiElement[] elements) {
+        for (DependenciesTree dependency : dependencies) {
+            String description = getDescription(dependency, dependencies.size());
+            ShowInDependenciesTree quickFix = new ShowInDependenciesTree(dependency, description);
+            Arrays.stream(elements)
+                    .filter(Objects::nonNull)
+                    .forEach(element -> problemsHolder.registerProblem(element, description, ProblemHighlightType.INFORMATION, quickFix));
+        }
+    }
+
+    /**
+     * Get the description of the show in dependencies tree quickfix.
+     *
+     * @param dependency       - The dependencies tree node
+     * @param dependenciesSize - The size of the dependencies tree list
+     * @return the description of the show in dependencies tree quickfix
+     */
+    private static String getDescription(DependenciesTree dependency, int dependenciesSize) {
+        if (dependenciesSize > 1) {
+            return SHOW_IN_DEPENDENCIES_TREE + " (" + ((DependenciesTree) dependency.getParent()).getUserObject() + ")";
+        }
+        return SHOW_IN_DEPENDENCIES_TREE;
+    }
+}

--- a/src/main/java/com/jfrog/ide/idea/inspections/MavenInspection.java
+++ b/src/main/java/com/jfrog/ide/idea/inspections/MavenInspection.java
@@ -1,0 +1,159 @@
+package com.jfrog.ide.idea.inspections;
+
+import com.google.common.collect.Sets;
+import com.intellij.codeInspection.ProblemsHolder;
+import com.intellij.lang.annotation.AnnotationHolder;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.XmlElementVisitor;
+import com.intellij.psi.impl.source.xml.XmlTagImpl;
+import com.intellij.psi.xml.XmlTag;
+import com.jfrog.ide.idea.scan.MavenScanManager;
+import com.jfrog.ide.idea.scan.ScanManager;
+import com.jfrog.ide.idea.scan.ScanManagersFactory;
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.idea.maven.project.MavenProject;
+import org.jetbrains.idea.maven.project.MavenProjectsManager;
+import org.jfrog.build.extractor.scan.DependenciesTree;
+import org.jfrog.build.extractor.scan.GeneralInfo;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @author yahavi
+ */
+@SuppressWarnings("InspectionDescriptionNotFoundInspection")
+public class MavenInspection extends AbstractInspection {
+
+    public static final String MAVEN_DEPENDENCY_MANAGEMENT = "dependencyManagement";
+    public static final String MAVEN_DEPENDENCIES_TAG = "dependencies";
+    public static final String MAVEN_ARTIFACT_ID_TAG = "artifactId";
+    public static final String MAVEN_GROUP_ID_TAG = "groupId";
+    public static final String MAVEN_VERSION_TAG = "version";
+
+    public MavenInspection() {
+        super("pom.xml");
+    }
+
+    @NotNull
+    @Override
+    public PsiElementVisitor buildVisitor(@NotNull final ProblemsHolder holder, boolean isOnTheFly) {
+        return new XmlElementVisitor() {
+            @Override
+            public void visitXmlTag(XmlTag element) {
+                super.visitElement(element);
+                MavenInspection.this.visitElement(holder, element);
+            }
+        };
+    }
+
+    @Override
+    public void annotate(@NotNull PsiElement element, @NotNull AnnotationHolder holder) {
+        if (element instanceof XmlTag) {
+            MavenInspection.this.visitElement(holder, element);
+        }
+    }
+
+    @Override
+    PsiElement[] getTargetElements(PsiElement element) {
+        XmlTag xmlTag = (XmlTag) element;
+        PsiElement groupId = xmlTag.findFirstSubTag(MAVEN_GROUP_ID_TAG);
+        PsiElement artifactId = xmlTag.findFirstSubTag(MAVEN_ARTIFACT_ID_TAG);
+        PsiElement version = xmlTag.findFirstSubTag(MAVEN_VERSION_TAG);
+        return new PsiElement[]{groupId, artifactId, version};
+    }
+
+    @Override
+    boolean isDependency(PsiElement element) {
+        PsiElement parentElement = element.getParent();
+        if (!(parentElement instanceof XmlTag) ||
+                !StringUtils.equals(((XmlTag) parentElement).getName(), MAVEN_DEPENDENCIES_TAG)) {
+            return false;
+        }
+        PsiElement grandParentElement = parentElement.getParent();
+        return !(grandParentElement instanceof XmlTag) ||
+                !StringUtils.equals(((XmlTag) parentElement).getName(), MAVEN_DEPENDENCY_MANAGEMENT);
+    }
+
+    @Override
+    ScanManager getScanManager(Project project, String path) {
+        return ScanManagersFactory.getScanManagers(project).stream()
+                .filter(MavenScanManager.class::isInstance)
+                .findAny()
+                .orElse(null);
+    }
+
+    @Override
+    GeneralInfo createGeneralInfo(PsiElement element) {
+        XmlTag groupId = ((XmlTagImpl) element).findFirstSubTag(MAVEN_GROUP_ID_TAG);
+        XmlTag artifactId = ((XmlTagImpl) element).findFirstSubTag(MAVEN_ARTIFACT_ID_TAG);
+        if (groupId == null || artifactId == null) {
+            return null;
+        }
+        return new GeneralInfo().groupId(groupId.getValue().getText()).artifactId(artifactId.getValue().getText());
+    }
+
+    @Override
+    Set<DependenciesTree> getModules(PsiElement element, GeneralInfo generalInfo) {
+        Project project = element.getProject();
+        DependenciesTree root = getRootDependenciesTree(element);
+        MavenProjectsManager mavenProjectsManager = MavenProjectsManager.getInstance(project);
+        if (root == null || mavenProjectsManager == null) {
+            return null;
+        }
+
+        List<MavenProject> mavenModules = mavenProjectsManager.getProjects();
+        // Single project, single module
+        if (mavenModules.size() <= 1 && root.getGeneralInfo() != null) {
+            return Sets.newHashSet(root);
+        }
+
+        // Multi project
+        root = getProjectNode(root, project);
+
+        // Multi module
+        if (isModule(mavenModules, generalInfo)) {
+            return Sets.newHashSet(root);
+        }
+
+        // Search for the relevant module
+        return collectModules(element, mavenProjectsManager, root);
+    }
+
+    /**
+     * Return true iff the dependency stated in the General info is a module in the project.
+     *
+     * @param mavenModules - The maven modules
+     * @param generalInfo  - General info of the dependency
+     * @return true iff the dependency stated in the General info is a module in the project
+     */
+    private boolean isModule(List<MavenProject> mavenModules, GeneralInfo generalInfo) {
+        return mavenModules.stream()
+                .map(MavenProject::getMavenId)
+                .map(mavenId -> new GeneralInfo().artifactId(mavenId.getArtifactId()).groupId(mavenId.getGroupId()))
+                .anyMatch(moduleGeneralInfo -> compareGeneralInfos(generalInfo, moduleGeneralInfo));
+    }
+
+    /**
+     * Collect all modules containing the dependency stated in the general info.
+     *
+     * @param element              - The element containing the dependency
+     * @param mavenProjectsManager - Maven project manager
+     * @return list of all nodes of the Maven modules
+     */
+    private Set<DependenciesTree> collectModules(PsiElement element, MavenProjectsManager mavenProjectsManager, DependenciesTree node) {
+        MavenProject mavenProject = mavenProjectsManager.findProject(element.getContainingFile().getVirtualFile());
+        if (mavenProject == null) {
+            return null;
+        }
+        node = node.getChildren().stream()
+                .filter(child -> StringUtils.equals(child.getGeneralInfo().getArtifactId(), mavenProject.getMavenId().getArtifactId()))
+                .filter(child -> StringUtils.equals(child.getGeneralInfo().getGroupId(), mavenProject.getMavenId().getGroupId()))
+                .findAny()
+                .orElse(node);
+        return Sets.newHashSet(node);
+    }
+}

--- a/src/main/java/com/jfrog/ide/idea/inspections/NpmInspection.java
+++ b/src/main/java/com/jfrog/ide/idea/inspections/NpmInspection.java
@@ -1,0 +1,107 @@
+package com.jfrog.ide.idea.inspections;
+
+import com.google.common.collect.Sets;
+import com.intellij.codeInspection.ProblemsHolder;
+import com.intellij.json.psi.JsonElementVisitor;
+import com.intellij.json.psi.JsonProperty;
+import com.intellij.lang.annotation.AnnotationHolder;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiElementVisitor;
+import com.jfrog.ide.idea.scan.ScanManager;
+import com.jfrog.ide.idea.scan.ScanManagersFactory;
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jfrog.build.extractor.scan.DependenciesTree;
+import org.jfrog.build.extractor.scan.GeneralInfo;
+
+import java.util.Set;
+
+/**
+ * @author yahavi
+ */
+@SuppressWarnings("InspectionDescriptionNotFoundInspection")
+public class NpmInspection extends AbstractInspection {
+
+    public NpmInspection() {
+        super("package.json");
+    }
+
+    @NotNull
+    @Override
+    public PsiElementVisitor buildVisitor(@NotNull final ProblemsHolder holder, boolean isOnTheFly) {
+        return new JsonElementVisitor() {
+            @Override
+            public void visitProperty(@NotNull JsonProperty element) {
+                super.visitProperty(element);
+                NpmInspection.this.visitElement(holder, element);
+            }
+        };
+    }
+
+    @Override
+    public void annotate(@NotNull PsiElement element, @NotNull AnnotationHolder holder) {
+        if (element instanceof JsonProperty) {
+            NpmInspection.this.visitElement(holder, element);
+        }
+    }
+
+    @Override
+    PsiElement[] getTargetElements(PsiElement element) {
+        return new PsiElement[]{element};
+    }
+
+    @Override
+    boolean isDependency(PsiElement element) {
+        PsiElement parentElement = element.getParent().getParent();
+        return parentElement != null && StringUtils.equalsAny(parentElement.getFirstChild().getText(), "\"dependencies\"", "\"devDependencies\"");
+    }
+
+    @Override
+    ScanManager getScanManager(Project project, String path) {
+        return ScanManagersFactory.getScanManagers(project).stream()
+                .filter(manager -> StringUtils.equals(manager.getProjectPath(), path))
+                .findAny()
+                .orElse(null);
+    }
+
+    @Override
+    Set<DependenciesTree> getModules(PsiElement element, GeneralInfo generalInfo) {
+        DependenciesTree root = getRootDependenciesTree(element);
+        if (root == null) {
+            return null;
+        }
+
+        // Single project, single module
+        if (root.getGeneralInfo() != null) {
+            return Sets.newHashSet(root);
+        }
+
+        // Multi project
+        String path = element.getContainingFile().getVirtualFile().getParent().getPath();
+        for (DependenciesTree child : root.getChildren()) {
+            if (isContainingPath(child, path)) {
+                return Sets.newHashSet(child);
+            }
+        }
+        return null;
+    }
+
+    @Override
+    GeneralInfo createGeneralInfo(PsiElement element) {
+        String artifactId = StringUtils.unwrap(element.getFirstChild().getText(), "\"");
+        return new GeneralInfo().artifactId(artifactId).groupId(artifactId);
+    }
+
+    /**
+     * Return true iff the dependencies tree node containing the input path.
+     *
+     * @param node - The dependencies tree node
+     * @param path - The path to check
+     * @return true iff the dependencies tree node containing the input path
+     */
+    private boolean isContainingPath(DependenciesTree node, String path) {
+        GeneralInfo childGeneralInfo = node.getGeneralInfo();
+        return StringUtils.equals(childGeneralInfo.getPath(), path);
+    }
+}

--- a/src/main/java/com/jfrog/ide/idea/inspections/ShowInDependenciesTree.java
+++ b/src/main/java/com/jfrog/ide/idea/inspections/ShowInDependenciesTree.java
@@ -1,0 +1,50 @@
+package com.jfrog.ide.idea.inspections;
+
+import com.intellij.codeInsight.intention.HighPriorityAction;
+import com.intellij.codeInspection.LocalQuickFix;
+import com.intellij.codeInspection.ProblemDescriptor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Iconable;
+import com.intellij.util.ui.tree.TreeUtil;
+import com.jfrog.ide.idea.ui.issues.IssuesTree;
+import com.jfrog.ide.idea.ui.utils.IconUtils;
+import com.jfrog.ide.idea.utils.Utils;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NotNull;
+import org.jfrog.build.extractor.scan.DependenciesTree;
+
+import javax.swing.*;
+
+/**
+ * Adds the yellow bulb action - "Show in dependencies tree".
+ *
+ * @author yahavi
+ */
+public class ShowInDependenciesTree implements LocalQuickFix, Iconable, HighPriorityAction {
+
+    private DependenciesTree node;
+    private String description;
+
+    public ShowInDependenciesTree(DependenciesTree node, String description) {
+        this.node = node;
+        this.description = description;
+    }
+
+    @Override
+    public Icon getIcon(int flags) {
+        return IconUtils.load("jfrog_icon");
+    }
+
+    @Nls(capitalization = Nls.Capitalization.Sentence)
+    @NotNull
+    @Override
+    public String getFamilyName() {
+        return description;
+    }
+
+    @Override
+    public void applyFix(@NotNull Project project, @NotNull ProblemDescriptor descriptor) {
+        Utils.focusJFrogToolWindow(project);
+        TreeUtil.selectInTree(project, node, true, IssuesTree.getInstance(project), true);
+    }
+}

--- a/src/main/java/com/jfrog/ide/idea/scan/ScanManager.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ScanManager.java
@@ -229,4 +229,9 @@ public abstract class ScanManager extends ScanManagerBase {
     boolean isScanInProgress() {
         return this.scanInProgress.get();
     }
+
+    public String getProjectPath() {
+        return project.getBasePath();
+    }
+
 }

--- a/src/main/java/com/jfrog/ide/idea/scan/ScanManagersFactory.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ScanManagersFactory.java
@@ -131,7 +131,7 @@ public class ScanManagersFactory {
             if (scanManager != null) {
                 scanManagers.put(projectHash, scanManager);
             } else {
-                scanManagers.put(projectHash, new NpmScanManager(mainProject, new NpmProject(dir)));
+                scanManagers.put(projectHash, new NpmScanManager(mainProject, new NpmProject(mainProject.getBaseDir(), dir)));
             }
         }
     }

--- a/src/main/java/com/jfrog/ide/idea/utils/Utils.java
+++ b/src/main/java/com/jfrog/ide/idea/utils/Utils.java
@@ -2,6 +2,9 @@ package com.jfrog.ide.idea.utils;
 
 import com.google.common.base.Objects;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.wm.ToolWindow;
+import com.intellij.openapi.wm.ToolWindowManager;
+import com.intellij.openapi.wm.impl.ToolWindowImpl;
 import com.jfrog.ide.idea.ui.listeners.IssuesTreeExpansionListener;
 import org.apache.commons.lang.StringUtils;
 import org.jfrog.build.extractor.scan.DependenciesTree;
@@ -39,6 +42,12 @@ public class Utils {
                 StringUtils.equals(lhsGeneralInfo.getPath(), rhsGeneralInfo.getPath());
     }
 
+    public static boolean gavStringEqual(GeneralInfo lhs, GeneralInfo rhs) {
+        return StringUtils.equals(lhs.getGroupId(), rhs.getGroupId()) &&
+                StringUtils.equals(lhs.getArtifactId(), rhs.getArtifactId()) &&
+                StringUtils.equals(lhs.getVersion(), rhs.getVersion());
+    }
+
     public static int getProjectIdentifier(String name, String path) {
         return Objects.hashCode(name, path);
     }
@@ -47,4 +56,8 @@ public class Utils {
         return getProjectIdentifier(project.getName(), project.getBasePath());
     }
 
+    public static void focusJFrogToolWindow(Project project) {
+        ToolWindow toolWindow = ToolWindowManager.getInstance(project).getToolWindow("JFrog");
+        ((ToolWindowImpl) toolWindow).fireActivated();
+    }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -14,10 +14,11 @@
     </change-notes>
 
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
-    <idea-version since-build="162"/>
+    <idea-version since-build="181"/>
     <depends>com.intellij.modules.lang</depends>
     <depends>org.jetbrains.plugins.gradle</depends>
     <depends>org.jetbrains.idea.maven</depends>
+    <depends>org.intellij.groovy</depends>
 
     <application-components>
         <component>
@@ -37,9 +38,32 @@
         <projectService serviceImplementation="com.jfrog.ide.idea.log.Logger"/>
         <toolWindow id="JFrog" anchor="bottom" icon="/icons/jfrog_icon.png"
                     factoryClass="com.jfrog.ide.idea.ui.JFrogToolWindowFactory" canCloseContents="false"/>
+
+        <localInspection language="JSON"
+                         displayName="Show in dependencies tree"
+                         groupBundle="messages.InspectionsBundle"
+                         groupKey="group.names.probable.bugs"
+                         enabledByDefault="true"
+                         implementationClass="com.jfrog.ide.idea.inspections.NpmInspection"/>
+        <localInspection language="XML"
+                         displayName="Show in dependencies tree"
+                         groupBundle="messages.InspectionsBundle"
+                         groupKey="group.names.probable.bugs"
+                         enabledByDefault="true"
+                         implementationClass="com.jfrog.ide.idea.inspections.MavenInspection"/>
+        <localInspection language="Groovy"
+                         displayName="Show in dependencies tree"
+                         groupBundle="messages.InspectionsBundle"
+                         groupKey="group.names.probable.bugs"
+                         enabledByDefault="true"
+                         implementationClass="com.jfrog.ide.idea.inspections.GradleInspection"/>
+        <annotator language="JSON" implementationClass="com.jfrog.ide.idea.inspections.NpmInspection"/>
+        <annotator language="XML" implementationClass="com.jfrog.ide.idea.inspections.MavenInspection"/>
+        <annotator language="Groovy" implementationClass="com.jfrog.ide.idea.inspections.GradleInspection"/>
     </extensions>
 
     <actions>
+        <!--suppress PluginXmlCapitalization -->
         <action id="Xray.Refresh"
                 class="com.jfrog.ide.idea.actions.RefreshAction"
                 text="Refresh scan"

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -19,6 +19,7 @@
     <depends>org.jetbrains.plugins.gradle</depends>
     <depends>org.jetbrains.idea.maven</depends>
     <depends>org.intellij.groovy</depends>
+    <depends>com.intellij.modules.java</depends>
 
     <application-components>
         <component>


### PR DESCRIPTION
1. Add "Show in dependencies tree" button.
2. Add "Licenses" and "Top issue" labels.

Bumped the minimal version to 2018.1 in order to fully support these features in Maven.