### PR TITLE
Bugfix: Gradle - don't recollect modules on soft refresh

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/GradleDependenciesDataService.java
+++ b/src/main/java/com/jfrog/ide/idea/GradleDependenciesDataService.java
@@ -49,7 +49,7 @@ public class GradleDependenciesDataService extends AbstractProjectDataService<Li
         }
 
         if (GlobalSettings.getInstance().areCredentialsSet()) {
-            ScanManagersFactory.getInstance(project).tryScanSingleProject(project, toImport, modelsProvider);
+            ScanManagersFactory.getInstance(project).tryScanSingleProject(project, toImport);
         }
     }
 }

--- a/src/main/java/com/jfrog/ide/idea/actions/RefreshAction.java
+++ b/src/main/java/com/jfrog/ide/idea/actions/RefreshAction.java
@@ -14,6 +14,6 @@ public class RefreshAction extends AnAction {
         if (e.getProject() == null) {
             return;
         }
-        ScanManagersFactory.getInstance(e.getProject()).startScan(false, null, null);
+        ScanManagersFactory.getInstance(e.getProject()).startScan(false, null);
     }
 }

--- a/src/main/java/com/jfrog/ide/idea/scan/MavenScanManager.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/MavenScanManager.java
@@ -5,7 +5,6 @@ import com.intellij.openapi.externalSystem.model.DataNode;
 import com.intellij.openapi.externalSystem.model.project.LibraryDependencyData;
 import com.intellij.openapi.externalSystem.model.project.ProjectData;
 import com.intellij.openapi.externalSystem.service.project.ExternalProjectRefreshCallback;
-import com.intellij.openapi.externalSystem.service.project.IdeModifiableModelsProvider;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.jfrog.ide.common.scan.ComponentPrefix;
@@ -55,7 +54,7 @@ public class MavenScanManager extends ScanManager {
     }
 
     @Override
-    protected void refreshDependencies(ExternalProjectRefreshCallback cbk, @Nullable Collection<DataNode<LibraryDependencyData>> libraryDependencies, @Nullable IdeModifiableModelsProvider modelsProvider) {
+    protected void refreshDependencies(ExternalProjectRefreshCallback cbk, @Nullable Collection<DataNode<LibraryDependencyData>> libraryDependencies) {
         cbk.onSuccess(null);
     }
 

--- a/src/main/java/com/jfrog/ide/idea/scan/NpmScanManager.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/NpmScanManager.java
@@ -4,7 +4,6 @@ import com.intellij.openapi.externalSystem.model.DataNode;
 import com.intellij.openapi.externalSystem.model.project.LibraryDependencyData;
 import com.intellij.openapi.externalSystem.model.project.ProjectData;
 import com.intellij.openapi.externalSystem.service.project.ExternalProjectRefreshCallback;
-import com.intellij.openapi.externalSystem.service.project.IdeModifiableModelsProvider;
 import com.intellij.openapi.project.Project;
 import com.intellij.util.EnvironmentUtil;
 import com.jfrog.ide.common.npm.NpmTreeBuilder;
@@ -38,7 +37,7 @@ public class NpmScanManager extends ScanManager {
     }
 
     @Override
-    protected void refreshDependencies(ExternalProjectRefreshCallback cbk, @Nullable Collection<DataNode<LibraryDependencyData>> libraryDependencies, @Nullable IdeModifiableModelsProvider modelsProvider) {
+    protected void refreshDependencies(ExternalProjectRefreshCallback cbk, @Nullable Collection<DataNode<LibraryDependencyData>> libraryDependencies) {
         cbk.onSuccess(null);
     }
 

--- a/src/main/java/com/jfrog/ide/idea/scan/ScanManager.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ScanManager.java
@@ -6,7 +6,6 @@ import com.intellij.openapi.externalSystem.model.DataNode;
 import com.intellij.openapi.externalSystem.model.project.LibraryDependencyData;
 import com.intellij.openapi.externalSystem.model.project.ProjectData;
 import com.intellij.openapi.externalSystem.service.project.ExternalProjectRefreshCallback;
-import com.intellij.openapi.externalSystem.service.project.IdeModifiableModelsProvider;
 import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.progress.Task;
@@ -72,7 +71,7 @@ public abstract class ScanManager extends ScanManagerBase {
     /**
      * Refresh project dependencies.
      */
-    protected abstract void refreshDependencies(ExternalProjectRefreshCallback cbk, @Nullable Collection<DataNode<LibraryDependencyData>> libraryDependencies, @Nullable IdeModifiableModelsProvider modelsProvider);
+    protected abstract void refreshDependencies(ExternalProjectRefreshCallback cbk, @Nullable Collection<DataNode<LibraryDependencyData>> libraryDependencies);
 
     /**
      * Collect and return {@link Components} to be scanned by JFrog Xray.
@@ -83,7 +82,7 @@ public abstract class ScanManager extends ScanManagerBase {
     /**
      * Scan and update dependency components.
      */
-    private void scanAndUpdate(boolean quickScan, ProgressIndicator indicator, @Nullable Collection<DataNode<LibraryDependencyData>> libraryDependencies, @Nullable IdeModifiableModelsProvider modelsProvider) {
+    private void scanAndUpdate(boolean quickScan, ProgressIndicator indicator, @Nullable Collection<DataNode<LibraryDependencyData>> libraryDependencies) {
         // Don't scan if Xray is not configured
         if (!GlobalSettings.getInstance().areCredentialsSet()) {
             getLog().error("Xray server is not configured.");
@@ -98,7 +97,7 @@ public abstract class ScanManager extends ScanManagerBase {
         }
         try {
             // Refresh dependencies -> Collect -> Scan and store to cache -> Update view
-            refreshDependencies(getRefreshDependenciesCbk(quickScan, indicator), libraryDependencies, modelsProvider);
+            refreshDependencies(getRefreshDependenciesCbk(quickScan, indicator), libraryDependencies);
         } finally {
             scanInProgress.set(false);
         }
@@ -107,7 +106,7 @@ public abstract class ScanManager extends ScanManagerBase {
     /**
      * Launch async dependency scan.
      */
-    void asyncScanAndUpdateResults(boolean quickScan, @Nullable Collection<DataNode<LibraryDependencyData>> libraryDependencies, @Nullable IdeModifiableModelsProvider modelsProvider) {
+    void asyncScanAndUpdateResults(boolean quickScan, @Nullable Collection<DataNode<LibraryDependencyData>> libraryDependencies) {
         if (DumbService.isDumb(mainProject)) { // If intellij is still indexing the project
             return;
         }
@@ -117,7 +116,7 @@ public abstract class ScanManager extends ScanManagerBase {
                 if (project.isDisposed()) {
                     return;
                 }
-                scanAndUpdate(quickScan, new ProgressIndicatorImpl(indicator), libraryDependencies, modelsProvider);
+                scanAndUpdate(quickScan, new ProgressIndicatorImpl(indicator), libraryDependencies);
                 indicator.finishNonCancelableSection();
             }
         };
@@ -144,7 +143,7 @@ public abstract class ScanManager extends ScanManagerBase {
      * Launch async dependency scan.
      */
     void asyncScanAndUpdateResults() {
-        asyncScanAndUpdateResults(true, null, null);
+        asyncScanAndUpdateResults(true, null);
     }
 
     private ExternalProjectRefreshCallback getRefreshDependenciesCbk(boolean quickScan, ProgressIndicator indicator) {

--- a/src/main/java/com/jfrog/ide/idea/scan/ScanManagersFactory.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ScanManagersFactory.java
@@ -5,7 +5,6 @@ import com.google.common.collect.Sets;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.externalSystem.model.DataNode;
 import com.intellij.openapi.externalSystem.model.project.LibraryDependencyData;
-import com.intellij.openapi.externalSystem.service.project.IdeModifiableModelsProvider;
 import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.jfrog.ide.idea.NpmProject;
@@ -51,9 +50,8 @@ public class ScanManagersFactory {
      *
      * @param quickScan           - True to allow usage of the scan cache.
      * @param libraryDependencies - Dependencies to use in Gradle scans.
-     * @param modelsProvider      - Modules to use in Gradle scans.
      */
-    public void startScan(boolean quickScan, @Nullable Collection<DataNode<LibraryDependencyData>> libraryDependencies, @Nullable IdeModifiableModelsProvider modelsProvider) {
+    public void startScan(boolean quickScan, @Nullable Collection<DataNode<LibraryDependencyData>> libraryDependencies) {
         if (DumbService.isDumb(mainProject)) { // If intellij is still indexing the project
             return;
         }
@@ -74,7 +72,7 @@ public class ScanManagersFactory {
             refreshScanManagers();
             resetViews(issuesTree, licensesTree);
             for (ScanManager scanManager : scanManagers.values()) {
-                scanManager.asyncScanAndUpdateResults(quickScan, libraryDependencies, modelsProvider);
+                scanManager.asyncScanAndUpdateResults(quickScan, libraryDependencies);
             }
         } catch (IOException | RuntimeException e) {
             Logger.getInstance(mainProject).error("", e);
@@ -88,15 +86,14 @@ public class ScanManagersFactory {
      *
      * @param project             - The Gradle project
      * @param libraryDependencies - Gradle's dependencies
-     * @param modelsProvider      - Gradle's modules
      */
-    public void tryScanSingleProject(Project project, Collection<DataNode<LibraryDependencyData>> libraryDependencies, IdeModifiableModelsProvider modelsProvider) {
+    public void tryScanSingleProject(Project project, Collection<DataNode<LibraryDependencyData>> libraryDependencies) {
         ScanManager scanManager = scanManagers.get(Utils.getProjectIdentifier(project));
         if (scanManager != null) { // If Gradle project already exists
-            scanManager.asyncScanAndUpdateResults(true, libraryDependencies, modelsProvider);
+            scanManager.asyncScanAndUpdateResults(true, libraryDependencies);
             return;
         }
-        startScan(true, libraryDependencies, modelsProvider); // New Gradle project
+        startScan(true, libraryDependencies); // New Gradle project
     }
 
     /**

--- a/src/main/java/com/jfrog/ide/idea/ui/JFrogToolWindowFactory.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/JFrogToolWindowFactory.java
@@ -27,7 +27,7 @@ public class JFrogToolWindowFactory implements ToolWindowFactory {
         boolean isSupported = CollectionUtils.isNotEmpty(ScanManagersFactory.getScanManagers(mainProject));
         DumbService.getInstance(mainProject).runWhenSmart(() -> {
             ServiceManager.getService(mainProject, JFrogToolWindow.class).initToolWindow(toolWindow, mainProject, isSupported);
-            scanManagersFactory.startScan(true, null, null);
+            scanManagersFactory.startScan(true, null);
         });
     }
 }


### PR DESCRIPTION
**Issue**
Currently when user makes a change in build.gradle or clicks on the "Reimport all Gradle projects" button, we tries to figure out if new modules added.
We can get a list of all Gradle modules but we can't know which one of them the user chose to import. 
Moreover, the module information we get is only partial. We only get the combined string <group>.<artifact>.
The results are duplications and redundant modules in the Dependencies tree. This causing unexpected behavior.

**Solution**
Keep the module data from the first scan and/or the last hard refresh. In soft refresh, change only the dependencies trees.