### PR TITLE
Improve inspection in Gradle

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/inspections/AbstractInspection.java
+++ b/src/main/java/com/jfrog/ide/idea/inspections/AbstractInspection.java
@@ -269,9 +269,9 @@ public abstract class AbstractInspection extends LocalInspectionTool implements 
 
     /**
      * Collect the nodes containing the dependency. Specifically handle the following cases:
-     * 1. The dependency is a module under node
-     * 2. The dependency is a direct dependency under node
-     * 3. The dependency is a level 2 dependency under node
+     * 1. The dependency is a module under the project node
+     * 2. The dependency is a direct dependency under the project node
+     * 3. The dependency is a level 2 dependency under the project node
      * @param projectNode          - The project node
      * @param generatedGeneralInfo - General info of the dependency
      * @return the nodes containing the dependency

--- a/src/main/java/com/jfrog/ide/idea/inspections/GoInspection.java
+++ b/src/main/java/com/jfrog/ide/idea/inspections/GoInspection.java
@@ -72,7 +72,7 @@ public class GoInspection extends AbstractInspection {
         if (root == null) {
             return null;
         }
-        return getModulesFromTree(element, root);
+        return collectModules(root, element);
     }
 
     @Override

--- a/src/main/java/com/jfrog/ide/idea/inspections/GradleInspection.java
+++ b/src/main/java/com/jfrog/ide/idea/inspections/GradleInspection.java
@@ -112,7 +112,7 @@ public class GradleInspection extends AbstractInspection {
         }
 
         // Collect the modules containing the dependency
-        return collectModules(project, gradleModules, root, generalInfo);
+        return collectModules(root, project, gradleModules, generalInfo);
     }
 
     /**

--- a/src/main/java/com/jfrog/ide/idea/inspections/MavenInspection.java
+++ b/src/main/java/com/jfrog/ide/idea/inspections/MavenInspection.java
@@ -103,6 +103,6 @@ public class MavenInspection extends AbstractInspection {
         }
 
         // Search for the relevant module
-        return collectModules(project, mavenProjectsManager.getProjects(), root, generalInfo);
+        return collectModules(root, project, mavenProjectsManager.getProjects(), generalInfo);
     }
 }

--- a/src/main/java/com/jfrog/ide/idea/inspections/NpmInspection.java
+++ b/src/main/java/com/jfrog/ide/idea/inspections/NpmInspection.java
@@ -71,7 +71,7 @@ public class NpmInspection extends AbstractInspection {
         if (root == null) {
             return null;
         }
-        return getModulesFromTree(element, root);
+        return collectModules(root, element);
     }
 
     @Override


### PR DESCRIPTION
Inspect "Multi project - Single module":
* Project 1 -
  * Dependency 1
  * Dependency 2
* Project 2
* Project 3

This fix make sure that dependencies 1 and 2 will be inspected for licenses and issues in `build.gradle`. The regular dependencies tree is not affected from this.