### PR TITLE
Support WebStorm and GoLand

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ repositories {
 }
 
 dependencies {
-    implementation group: 'com.jfrog.ide', name: 'ide-plugins-common', version: '1.2.x-SNAPSHOT'
+    implementation group: 'com.jfrog.ide', name: 'ide-plugins-common', version: '1.3.0'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.9'
 }
 

--- a/src/main/java/com/jfrog/ide/idea/scan/ScanManagersFactory.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ScanManagersFactory.java
@@ -8,10 +8,10 @@ import com.intellij.openapi.externalSystem.model.project.LibraryDependencyData;
 import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.jfrog.ide.common.utils.PackageFileFinder;
-import com.jfrog.ide.idea.projects.GoProject;
-import com.jfrog.ide.idea.projects.NpmProject;
 import com.jfrog.ide.idea.configuration.GlobalSettings;
 import com.jfrog.ide.idea.log.Logger;
+import com.jfrog.ide.idea.projects.GoProject;
+import com.jfrog.ide.idea.projects.NpmProject;
 import com.jfrog.ide.idea.ui.issues.IssuesTree;
 import com.jfrog.ide.idea.ui.licenses.LicensesTree;
 import com.jfrog.ide.idea.utils.Utils;
@@ -107,12 +107,8 @@ public class ScanManagersFactory {
         if (scanManager != null) {
             scanManagers.put(projectHash, scanManager);
         } else {
-            if (MavenScanManager.isApplicable(mainProject)) {
-                scanManagers.put(projectHash, createScanManager(ScanManagerTypes.MAVEN, mainProject, ""));
-            }
-            if (GradleScanManager.isApplicable(mainProject)) {
-                scanManagers.put(projectHash, createScanManager(ScanManagerTypes.GRADLE, mainProject, ""));
-            }
+            createScanManagerIfApplicable(scanManagers, projectHash, ScanManagerTypes.MAVEN, "");
+            createScanManagerIfApplicable(scanManagers, projectHash, ScanManagerTypes.GRADLE, "");
         }
         paths.add(Utils.getProjectBasePath(mainProject));
         createScanManagers(scanManagers, paths);
@@ -140,7 +136,7 @@ public class ScanManagersFactory {
             if (scanManager != null) {
                 scanManagers.put(projectHash, scanManager);
             } else {
-                scanManagers.put(projectHash, createScanManager(type, mainProject, dir));
+                createScanManagerIfApplicable(scanManagers, projectHash, type, dir);
             }
         }
     }
@@ -152,18 +148,40 @@ public class ScanManagersFactory {
         GO
     }
 
-    private ScanManager createScanManager(ScanManagerTypes type, Project project, String dir) throws IOException {
-        switch (type) {
-            case MAVEN:
-                return new MavenScanManager(project);
-            case GRADLE:
-                return new GradleScanManager(project);
-            case NPM:
-                return new NpmScanManager(project, new NpmProject(project.getBaseDir(), dir));
-            case GO:
-                return new GoScanManager(project, new GoProject(project.getBaseDir(), dir));
+    /**
+     * Create a new scan manager according to the scan manager type. Add it to the scan managers set.
+     * Maven - Create only if 'maven' plugin is installed and there are Maven projects.
+     * Gradle - Create only if 'gradle' plugin is installed and there are Gradle projects.
+     * Go & npm - Always create.
+     *
+     * @param scanManagers - Scan managers set
+     * @param projectHash  - Project hash - calculated by the project name and the path
+     * @param type         - Project type
+     * @param dir          - Project dir
+     * @throws IOException in any case of error during scan manager creation.
+     */
+    private void createScanManagerIfApplicable(Map<Integer, ScanManager> scanManagers, int projectHash, ScanManagerTypes type, String dir) throws IOException {
+        try {
+            switch (type) {
+                case MAVEN:
+                    if (MavenScanManager.isApplicable(mainProject)) {
+                        scanManagers.put(projectHash, new MavenScanManager(mainProject));
+                    }
+                    return;
+                case GRADLE:
+                    if (GradleScanManager.isApplicable(mainProject)) {
+                        scanManagers.put(projectHash, new GradleScanManager(mainProject));
+                    }
+                    return;
+                case NPM:
+                    scanManagers.put(projectHash, new NpmScanManager(mainProject, new NpmProject(mainProject.getBaseDir(), dir)));
+                    return;
+                case GO:
+                    scanManagers.put(projectHash, new GoScanManager(mainProject, new GoProject(mainProject.getBaseDir(), dir)));
+            }
+        } catch (NoClassDefFoundError noClassDefFoundError) {
+            // The 'maven' or 'gradle' plugins are not installed.
         }
-        throw new IOException("Invalid scan-manager type provided.");
     }
 
     private boolean isScanInProgress() {

--- a/src/main/java/com/jfrog/ide/idea/ui/utils/ComponentUtils.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/utils/ComponentUtils.java
@@ -27,7 +27,7 @@ import java.util.List;
  */
 public class ComponentUtils {
 
-    public static final String UNSUPPORTED_TEXT = "Unsupported project type, currently only Maven, Gradle and npm projects are supported.";
+    public static final String UNSUPPORTED_TEXT = "Unsupported project type, currently only Maven, Gradle, Go and npm projects are supported.";
     public static final String SELECT_COMPONENT_TEXT = "Select component or issue for more details.";
 
     public static JTextArea createJTextArea(String text, boolean lineWrap) {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -19,10 +19,7 @@
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
     <idea-version since-build="183.3795.13"/>
     <depends>com.intellij.modules.lang</depends>
-    <depends>org.jetbrains.plugins.gradle</depends>
-    <depends>org.jetbrains.idea.maven</depends>
-    <depends>org.intellij.groovy</depends>
-    <depends>com.intellij.modules.java</depends>
+    <depends config-file="with-java.xml" optional="true">com.intellij.modules.java</depends>
     <depends config-file="with-go.xml" optional="true">org.jetbrains.plugins.go</depends>
 
     <application-components>
@@ -50,21 +47,7 @@
                          groupKey="group.names.probable.bugs"
                          enabledByDefault="true"
                          implementationClass="com.jfrog.ide.idea.inspections.NpmInspection"/>
-        <localInspection language="XML"
-                         displayName="Show in dependencies tree"
-                         groupBundle="messages.InspectionsBundle"
-                         groupKey="group.names.probable.bugs"
-                         enabledByDefault="true"
-                         implementationClass="com.jfrog.ide.idea.inspections.MavenInspection"/>
-        <localInspection language="Groovy"
-                         displayName="Show in dependencies tree"
-                         groupBundle="messages.InspectionsBundle"
-                         groupKey="group.names.probable.bugs"
-                         enabledByDefault="true"
-                         implementationClass="com.jfrog.ide.idea.inspections.GradleInspection"/>
         <annotator language="JSON" implementationClass="com.jfrog.ide.idea.inspections.NpmInspection"/>
-        <annotator language="XML" implementationClass="com.jfrog.ide.idea.inspections.MavenInspection"/>
-        <annotator language="Groovy" implementationClass="com.jfrog.ide.idea.inspections.GradleInspection"/>
     </extensions>
 
     <actions>

--- a/src/main/resources/META-INF/with-gradle.xml
+++ b/src/main/resources/META-INF/with-gradle.xml
@@ -1,0 +1,12 @@
+<idea-plugin>
+    <depends>org.intellij.groovy</depends>
+    <extensions defaultExtensionNs="com.intellij">
+        <localInspection language="Groovy"
+                         displayName="Show in dependencies tree"
+                         groupBundle="messages.InspectionsBundle"
+                         groupKey="group.names.probable.bugs"
+                         enabledByDefault="true"
+                         implementationClass="com.jfrog.ide.idea.inspections.GradleInspection"/>
+        <annotator language="Groovy" implementationClass="com.jfrog.ide.idea.inspections.GradleInspection"/>
+    </extensions>
+</idea-plugin>

--- a/src/main/resources/META-INF/with-java.xml
+++ b/src/main/resources/META-INF/with-java.xml
@@ -1,0 +1,4 @@
+<idea-plugin>
+    <depends config-file="with-gradle.xml" optional="true">org.jetbrains.plugins.gradle</depends>
+    <depends config-file="with-maven.xml" optional="true">org.jetbrains.idea.maven</depends>
+</idea-plugin>

--- a/src/main/resources/META-INF/with-maven.xml
+++ b/src/main/resources/META-INF/with-maven.xml
@@ -1,0 +1,11 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <localInspection language="XML"
+                         displayName="Show in dependencies tree"
+                         groupBundle="messages.InspectionsBundle"
+                         groupKey="group.names.probable.bugs"
+                         enabledByDefault="true"
+                         implementationClass="com.jfrog.ide.idea.inspections.MavenInspection"/>
+        <annotator language="XML" implementationClass="com.jfrog.ide.idea.inspections.MavenInspection"/>
+    </extensions>
+</idea-plugin>


### PR DESCRIPTION
Remove the obstacles to support _WebStorm_ and _GoLand_.

* Remove dependency on Java plugins by making 'maven', 'gradle', 'java' and 'groovy' plugins optional. This also will turn off inspections respectively.
* Catch `NoClassDefFoundError` when checking if Maven and Gradle are applicable. This is our sign that 'maven' or 'gradle' plugins are not installed.
* Fix the "unsupported" message.

With all of the above the plugin can work on _WebStorm_ and _GoLand_. During the next release we will be able to mark _WebStorm_ and _GoLand_ as supported in the marketplace.

**_Android Studio_**
Sadly, _Android Studio_ does not build Gradle dependencies tree as Intellij Idea does. However, this PR may take us one step forward toward supporting it in the future, as requested in #55.