### PR TITLE
Bugfix - UI on Gradle projects may freeze on start scanning

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/scan/ScanManager.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ScanManager.java
@@ -165,7 +165,9 @@ public abstract class ScanManager extends ScanManagerBase {
      * @return all project modules locations as Paths
      */
     public Set<Path> getProjectPaths() {
-        return Sets.newHashSet(Utils.getProjectBasePath(project));
+        Set<Path> paths = Sets.newHashSet();
+        paths.add(Utils.getProjectBasePath(project));
+        return paths;
     }
 
     /**


### PR DESCRIPTION
Projects paths are the base paths of open projects in Intellij.
We collect them from the Maven and Gradle scanners to search for go.mod and package.json files.

Calling getProjectPaths on Gradle projects return incorrect results:

```java
// Expected:
{"path/to/project/base"}

// Actual:
{"path", "to", "project", "base"}
```
This happen because `Sets.newHashSet(Path);` disintegrate the Path object to its iterable parts.

This issue may result in long searching of package.json and go.mod files in non expected locations in the file system.