### PR TITLE
Add functionality to exclude Maven transitive dependencies from issues-tree

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/exclusion/Excludable.java
+++ b/src/main/java/com/jfrog/ide/idea/exclusion/Excludable.java
@@ -1,0 +1,15 @@
+package com.jfrog.ide.idea.exclusion;
+
+import com.intellij.openapi.project.Project;
+
+/**
+ * Created by Bar Belity on 28/05/2020.
+ */
+public interface Excludable {
+
+    /**
+     * Exclude from project-descriptor.
+     */
+    void exclude(Project project);
+
+}

--- a/src/main/java/com/jfrog/ide/idea/exclusion/ExclusionUtils.java
+++ b/src/main/java/com/jfrog/ide/idea/exclusion/ExclusionUtils.java
@@ -1,0 +1,44 @@
+package com.jfrog.ide.idea.exclusion;
+
+import com.jfrog.ide.idea.navigation.NavigationTarget;
+import org.jfrog.build.extractor.scan.DependenciesTree;
+
+/**
+ * Created by Bar Belity on 28/05/2020.
+ */
+public class ExclusionUtils {
+
+    /**
+     * Check if a specific node from the Dependencies-tree can be excluded from project-descriptor.
+     *
+     * @param nodeToExclude - The node in tree to exclude.
+     * @param affectedNode  - Direct dependency's node in tree which will be affected by the exclusion.
+     * @return true if the provided nodeToExclude can be excluded from project-descriptor.
+     */
+    public static boolean isExcludable(DependenciesTree nodeToExclude, DependenciesTree affectedNode) {
+        if ("maven".equals(nodeToExclude.getGeneralInfo().getPkgType())) {
+            DependenciesTree rootNode = (DependenciesTree) nodeToExclude.getRoot();
+            if ("maven".equals(rootNode.getGeneralInfo().getPkgType())) {
+                return MavenExclusion.isExcludable(nodeToExclude, affectedNode);
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Get the corresponding Excludable object for the node to exclude.
+     *
+     * @param nodeToExclude    - The node in tree to exclude.
+     * @param navigationTarget - The navigation-target of the node to exclude.
+     * @return the corresponding Excludable object, Null if exclusion is not supported for this node.
+     */
+    public static Excludable getExcludable(DependenciesTree nodeToExclude, NavigationTarget navigationTarget) {
+        if ("maven".equals(nodeToExclude.getGeneralInfo().getPkgType())) {
+            DependenciesTree rootNode = (DependenciesTree) nodeToExclude.getRoot();
+            if ("maven".equals(rootNode.getGeneralInfo().getPkgType())) {
+                return new MavenExclusion(nodeToExclude, navigationTarget);
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/jfrog/ide/idea/exclusion/ExclusionUtils.java
+++ b/src/main/java/com/jfrog/ide/idea/exclusion/ExclusionUtils.java
@@ -16,11 +16,8 @@ public class ExclusionUtils {
      * @return true if the provided nodeToExclude can be excluded from project-descriptor.
      */
     public static boolean isExcludable(DependenciesTree nodeToExclude, DependenciesTree affectedNode) {
-        if ("maven".equals(nodeToExclude.getGeneralInfo().getPkgType())) {
-            DependenciesTree rootNode = (DependenciesTree) nodeToExclude.getRoot();
-            if ("maven".equals(rootNode.getGeneralInfo().getPkgType())) {
-                return MavenExclusion.isExcludable(nodeToExclude, affectedNode);
-            }
+        if (MavenExclusion.isMavenPackageType(nodeToExclude)) {
+            return MavenExclusion.isExcludable(nodeToExclude, affectedNode);
         }
         return false;
     }
@@ -32,10 +29,9 @@ public class ExclusionUtils {
      * @param navigationTarget - The navigation-target of the node to exclude.
      * @return the corresponding Excludable object, Null if exclusion is not supported for this node.
      */
-    public static Excludable getExcludable(DependenciesTree nodeToExclude, NavigationTarget navigationTarget) {
-        if ("maven".equals(nodeToExclude.getGeneralInfo().getPkgType())) {
-            DependenciesTree rootNode = (DependenciesTree) nodeToExclude.getRoot();
-            if ("maven".equals(rootNode.getGeneralInfo().getPkgType())) {
+    public static Excludable getExcludable(DependenciesTree nodeToExclude, DependenciesTree affectedNode, NavigationTarget navigationTarget) {
+        if (MavenExclusion.isMavenPackageType(nodeToExclude)) {
+            if (MavenExclusion.isExcludable(nodeToExclude, affectedNode)) {
                 return new MavenExclusion(nodeToExclude, navigationTarget);
             }
         }

--- a/src/main/java/com/jfrog/ide/idea/exclusion/MavenExclusion.java
+++ b/src/main/java/com/jfrog/ide/idea/exclusion/MavenExclusion.java
@@ -1,0 +1,87 @@
+package com.jfrog.ide.idea.exclusion;
+
+import com.intellij.openapi.command.WriteCommandAction;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiManager;
+import com.intellij.psi.xml.XmlFile;
+import com.intellij.psi.xml.XmlTag;
+import com.jfrog.ide.idea.inspections.MavenInspection;
+import com.jfrog.ide.idea.navigation.NavigationTarget;
+import org.jfrog.build.extractor.scan.DependenciesTree;
+
+/**
+ * Created by Bar Belity on 28/05/2020.
+ */
+public class MavenExclusion implements Excludable {
+
+    public static final String MAVEN_EXCLUSIONS_TAG = "exclusions";
+    public static final String MAVEN_EXCLUSION_TAG = "exclusion";
+    private DependenciesTree nodeToExclude;
+    private NavigationTarget navigationTarget;
+
+    public MavenExclusion(DependenciesTree nodeToExclude, NavigationTarget navigationTarget) {
+        this.nodeToExclude = nodeToExclude;
+        this.navigationTarget = navigationTarget;
+    }
+
+    public static boolean isExcludable(DependenciesTree nodeToExclude, DependenciesTree affectedNode) {
+        return nodeToExclude.getGeneralInfo().getPkgType().equals("maven") && !nodeToExclude.equals(affectedNode);
+    }
+
+    @Override
+    public void exclude(Project project) {
+        PsiFile psiFile = PsiManager.getInstance(project).findFile(navigationTarget.getElement().getContainingFile().getVirtualFile());
+        if (!(psiFile instanceof XmlFile)) {
+            return;
+        }
+        XmlFile file = (XmlFile) psiFile;
+
+        WriteCommandAction.writeCommandAction(project, file).run(() -> {
+            String groupId = nodeToExclude.getGeneralInfo().getGroupId();
+            String artifactId = nodeToExclude.getGeneralInfo().getArtifactId();
+            if (!(navigationTarget.getElement() instanceof XmlTag)) {
+                return;
+            }
+            XmlTag xmlElement = (XmlTag) navigationTarget.getElement();
+            XmlTag exclusionsTag = xmlElement.findFirstSubTag(MAVEN_EXCLUSIONS_TAG);
+            if (exclusionsTag == null) {
+                exclusionsTag = xmlElement.createChildTag(MAVEN_EXCLUSIONS_TAG, "", "", false);
+                createAndAddExclusionTags(exclusionsTag, groupId, artifactId);
+                xmlElement.addSubTag(exclusionsTag, false);
+                return;
+            }
+
+            XmlTag[] allExclusions = exclusionsTag.findSubTags(MAVEN_EXCLUSION_TAG);
+            if (exclusionExists(allExclusions, groupId, artifactId)) {
+                // Don't create exclusion tag.
+                return;
+            }
+            createAndAddExclusionTags(exclusionsTag, groupId, artifactId);
+        });
+    }
+
+    private boolean exclusionExists(XmlTag[] allExclusions, String groupId, String artifactId) {
+        for (XmlTag exclusionTag : allExclusions) {
+            XmlTag groupIdTag = exclusionTag.findFirstSubTag(MavenInspection.MAVEN_GROUP_ID_TAG);
+            if (groupIdTag == null || !groupId.equals(groupIdTag.getValue().getText())) {
+                continue;
+            }
+            XmlTag artifactIdTag = exclusionTag.findFirstSubTag(MavenInspection.MAVEN_ARTIFACT_ID_TAG);
+            if (artifactIdTag == null || !artifactId.equals(artifactIdTag.getValue().getText())) {
+                continue;
+            }
+            return true;
+        }
+        return false;
+    }
+
+    private void createAndAddExclusionTags(XmlTag exclusionsTag, String groupId, String artifactId) {
+        XmlTag exclusionTag = exclusionsTag.createChildTag(MAVEN_EXCLUSION_TAG, "", "", false);
+        XmlTag groupIdTag = exclusionTag.createChildTag(MavenInspection.MAVEN_GROUP_ID_TAG, "", groupId, false);
+        XmlTag artifactIdTag = exclusionTag.createChildTag(MavenInspection.MAVEN_ARTIFACT_ID_TAG, "", artifactId, false);
+        exclusionTag.addSubTag(groupIdTag, true);
+        exclusionTag.addSubTag(artifactIdTag, false);
+        exclusionsTag.addSubTag(exclusionTag, false);
+    }
+}

--- a/src/main/java/com/jfrog/ide/idea/navigation/NavigationService.java
+++ b/src/main/java/com/jfrog/ide/idea/navigation/NavigationService.java
@@ -28,8 +28,17 @@ public class NavigationService {
     }
 
     /**
+     * Clear existing navigation map.
+     */
+    public static void clearNavigationMap(@NotNull Project project) {
+        NavigationService navigationService = NavigationService.getInstance(project);
+        navigationService.navigationMap.clear();
+    }
+
+    /**
      * Add a navigation element to the node in tree.
-     * @param treeNode The tree-node to register the navigation from.
+     *
+     * @param treeNode                The tree-node to register the navigation from.
      * @param navigationTargetElement The PsiElement we register the navigation to.
      */
     public void addNavigation(DependenciesTree treeNode, PsiElement navigationTargetElement) {
@@ -40,7 +49,7 @@ public class NavigationService {
             return;
         }
 
-        NavigationTarget navigationTarget = new NavigationTarget(containingFile.getVirtualFile(), document.getLineNumber(navigationTargetElement.getTextOffset()));
+        NavigationTarget navigationTarget = new NavigationTarget(navigationTargetElement, document.getLineNumber(navigationTargetElement.getTextOffset()));
         Set<NavigationTarget> navigationTargets = navigationMap.get(treeNode);
         if (navigationTargets == null) {
             navigationTargets = new HashSet<>(Collections.singletonList(navigationTarget));
@@ -52,6 +61,7 @@ public class NavigationService {
 
     /**
      * Get navigation targets for a specific node in tree.
+     *
      * @param treeNode The tree-node to get its navigation.
      * @return Set of candidates for navigation.
      */
@@ -61,6 +71,7 @@ public class NavigationService {
 
     /**
      * Get a navigable ancestor of a DependenciesTree node, in the issues tree.
+     *
      * @param node To find its navigable ancestor.
      * @return The first navigable ancestor of 'node', null of not found.
      */
@@ -73,13 +84,5 @@ public class NavigationService {
             parentCandidate = (DependenciesTree) parentCandidate.getParent();
         }
         return null;
-    }
-
-    /**
-     * Clear existing navigation map.
-     */
-    public static void clearNavigationMap(@NotNull Project project) {
-        NavigationService navigationService = NavigationService.getInstance(project);
-        navigationService.navigationMap.clear();
     }
 }

--- a/src/main/java/com/jfrog/ide/idea/navigation/NavigationTarget.java
+++ b/src/main/java/com/jfrog/ide/idea/navigation/NavigationTarget.java
@@ -1,6 +1,6 @@
 package com.jfrog.ide.idea.navigation;
 
-import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiElement;
 
 import java.util.Objects;
 
@@ -9,16 +9,16 @@ import java.util.Objects;
  */
 public class NavigationTarget {
 
-    private VirtualFile virtualFile;
+    private PsiElement element;
     private int lineNumber;
 
-    NavigationTarget(VirtualFile virtualFile, int lineNumber) {
-        this.virtualFile = virtualFile;
+    NavigationTarget(PsiElement element, int lineNumber) {
+        this.element = element;
         this.lineNumber = lineNumber;
     }
 
-    public VirtualFile getVirtualFile() {
-        return virtualFile;
+    public PsiElement getElement() {
+        return element;
     }
 
     public int getLineNumber() {
@@ -31,11 +31,11 @@ public class NavigationTarget {
         if (!(o instanceof NavigationTarget)) return false;
         NavigationTarget that = (NavigationTarget) o;
         return lineNumber == that.lineNumber &&
-                Objects.equals(virtualFile, that.virtualFile);
+                Objects.equals(element, that.element);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(virtualFile, lineNumber);
+        return Objects.hash(element, lineNumber);
     }
 }

--- a/src/main/java/com/jfrog/ide/idea/scan/MavenScanManager.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/MavenScanManager.java
@@ -8,6 +8,7 @@ import com.intellij.openapi.externalSystem.model.project.ProjectData;
 import com.intellij.openapi.externalSystem.service.project.ExternalProjectRefreshCallback;
 import com.intellij.openapi.fileTypes.StdFileTypes;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.search.FilenameIndex;
@@ -20,7 +21,10 @@ import org.jetbrains.annotations.Nullable;
 import org.jetbrains.idea.maven.model.MavenArtifactNode;
 import org.jetbrains.idea.maven.model.MavenId;
 import org.jetbrains.idea.maven.project.MavenProject;
+import org.jetbrains.idea.maven.project.MavenProjectChanges;
 import org.jetbrains.idea.maven.project.MavenProjectsManager;
+import org.jetbrains.idea.maven.project.MavenProjectsTree;
+import org.jetbrains.idea.maven.server.NativeMavenProjectHolder;
 import org.jfrog.build.extractor.scan.DependenciesTree;
 import org.jfrog.build.extractor.scan.GeneralInfo;
 
@@ -39,7 +43,7 @@ public class MavenScanManager extends ScanManager {
 
     MavenScanManager(Project project) throws IOException {
         super(project, project, ComponentPrefix.GAV);
-        MavenProjectsManager.getInstance(project).addManagerListener(new MavenProjectsListener());
+        MavenProjectsManager.getInstance(project).addProjectsTreeListener(new MavenProjectsTreeListener());
     }
 
     static boolean isApplicable(@NotNull Project project) {
@@ -154,20 +158,13 @@ public class MavenScanManager extends ScanManager {
     }
 
     /**
-     * Maven project listener for scanning artifacts on dependencies changes.
+     * Maven projects tree listener for scanning artifacts on dependencies changes.
      */
-    private class MavenProjectsListener implements MavenProjectsManager.Listener {
 
+    private final class MavenProjectsTreeListener implements MavenProjectsTree.Listener {
         @Override
-        public void activated() {
-        }
-
-        @Override
-        public void projectsScheduled() {
-        }
-
-        @Override
-        public void importAndResolveScheduled() {
+        public void projectResolved(@NotNull Pair<MavenProject, MavenProjectChanges> projectWithChanges,
+                                    NativeMavenProjectHolder nativeMavenProject) {
             asyncScanAndUpdateResults();
         }
     }

--- a/src/main/java/com/jfrog/ide/idea/ui/issues/IssuesTree.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/issues/IssuesTree.java
@@ -229,29 +229,37 @@ public class IssuesTree extends BaseTree {
     }
 
     private void addNodeExclusion(DependenciesTree nodeToExclude, Set<NavigationTarget> parentCandidates, DependenciesTree affectedNode) {
+        if (parentCandidates.size() > 1) {
+            addMultiExclusion(nodeToExclude, affectedNode, parentCandidates);
+        } else {
+            addSingleExclusion(nodeToExclude, affectedNode, parentCandidates.iterator().next());
+        }
+    }
+
+    private void addMultiExclusion(DependenciesTree nodeToExclude, DependenciesTree affectedNode, Set<NavigationTarget> parentCandidates) {
         if (!ExclusionUtils.isExcludable(nodeToExclude, affectedNode)) {
             return;
         }
-        if (parentCandidates.size() > 1) {
-            addMultiExclusion(nodeToExclude, parentCandidates);
-        } else {
-            addSingleExclusion(nodeToExclude, parentCandidates.iterator().next());
-        }
-    }
-
-    private void addMultiExclusion(DependenciesTree nodeToExclude, Set<NavigationTarget> parentCandidates) {
         JMenu multiMenu = new JBMenu();
         multiMenu.setText(EXCLUDE_DEPENDENCY);
         for (NavigationTarget parentCandidate : parentCandidates) {
-            Excludable excludable = ExclusionUtils.getExcludable(nodeToExclude, parentCandidate);
+            Excludable excludable = ExclusionUtils.getExcludable(nodeToExclude, affectedNode, parentCandidate);
+            if (excludable == null) {
+                continue;
+            }
             String descriptorPath = getRelativizedDescriptorPath(parentCandidate);
             multiMenu.add(createExcludeMenuItem(excludable, descriptorPath + " " + (parentCandidate.getLineNumber() + 1)));
         }
-        popupMenu.add(multiMenu);
+        if (multiMenu.getItemCount() > 0) {
+            popupMenu.add(multiMenu);
+        }
     }
 
-    private void addSingleExclusion(DependenciesTree nodeToExclude, NavigationTarget parentCandidate) {
-        Excludable excludable = ExclusionUtils.getExcludable(nodeToExclude, parentCandidate);
+    private void addSingleExclusion(DependenciesTree nodeToExclude, DependenciesTree affectedNode, NavigationTarget parentCandidate) {
+        Excludable excludable = ExclusionUtils.getExcludable(nodeToExclude, affectedNode, parentCandidate);
+        if (excludable == null) {
+            return;
+        }
         popupMenu.add(createExcludeMenuItem(excludable, EXCLUDE_DEPENDENCY));
     }
 

--- a/src/main/java/com/jfrog/ide/idea/ui/issues/IssuesTree.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/issues/IssuesTree.java
@@ -2,15 +2,19 @@ package com.jfrog.ide.idea.ui.issues;
 
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.ServiceManager;
-import com.intellij.openapi.fileEditor.OpenFileDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.JBMenuItem;
 import com.intellij.openapi.ui.JBPopupMenu;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.pom.Navigatable;
+import com.intellij.psi.PsiInvalidElementAccessException;
 import com.intellij.ui.components.JBMenu;
 import com.intellij.util.messages.MessageBusConnection;
 import com.jfrog.ide.common.filter.FilterManager;
 import com.jfrog.ide.common.utils.ProjectsMap;
 import com.jfrog.ide.idea.events.ProjectEvents;
+import com.jfrog.ide.idea.exclusion.Excludable;
+import com.jfrog.ide.idea.exclusion.ExclusionUtils;
 import com.jfrog.ide.idea.log.Logger;
 import com.jfrog.ide.idea.navigation.NavigationService;
 import com.jfrog.ide.idea.navigation.NavigationTarget;
@@ -38,19 +42,20 @@ import java.util.stream.IntStream;
  */
 public class IssuesTree extends BaseTree {
 
-    private static final String POPUP_MENU_HEADLINE = "Show in project descriptor";
+    private static final String SHOW_IN_PROJECT_DESCRIPTOR = "Show in project descriptor";
+    private static final String EXCLUDE_DEPENDENCY = "Exclude dependency";
     private IssuesTreeExpansionListener issuesTreeExpansionListener;
     private JPanel issuesCountPanel;
     private JLabel issuesCount;
     private JBPopupMenu popupMenu = new JBPopupMenu();
 
-    public static IssuesTree getInstance(@NotNull Project project) {
-        return ServiceManager.getService(project, IssuesTree.class);
-    }
-
     private IssuesTree(@NotNull Project mainProject) {
         super(mainProject);
         setCellRenderer(new IssuesTreeCellRenderer());
+    }
+
+    public static IssuesTree getInstance(@NotNull Project project) {
+        return ServiceManager.getService(project, IssuesTree.class);
     }
 
     void setIssuesCountLabel(JLabel issuesCount) {
@@ -150,33 +155,38 @@ public class IssuesTree extends BaseTree {
         popupMenu.removeAll();
         NavigationService navigationService = NavigationService.getInstance(mainProject);
         Set<NavigationTarget> navigationCandidates = navigationService.getNavigation(selectedNode);
+        DependenciesTree affectedNode = selectedNode;
         if (navigationCandidates == null) {
-            // Find parent for navigation.
-            selectedNode = navigationService.getNavigableParent(selectedNode);
-            if (selectedNode == null) {
+            // Find the direct dependency containing the selected dependency.
+            affectedNode = navigationService.getNavigableParent(selectedNode);
+            if (affectedNode == null) {
                 return;
             }
-            navigationCandidates = navigationService.getNavigation(selectedNode);
+            navigationCandidates = navigationService.getNavigation(affectedNode);
             if (navigationCandidates == null) {
                 return;
             }
         }
 
+        addNodeNavigation(navigationCandidates);
+        addNodeExclusion(selectedNode, navigationCandidates, affectedNode);
+    }
+
+    private void addNodeNavigation(Set<NavigationTarget> navigationCandidates) {
         if (navigationCandidates.size() > 1) {
             addMultiNavigation(navigationCandidates);
         } else {
-            addSingleNavigation(navigationCandidates);
+            addSingleNavigation(navigationCandidates.iterator().next());
         }
     }
 
-    private void addSingleNavigation(Set<NavigationTarget> navigationCandidates) {
-        NavigationTarget navigationTarget = navigationCandidates.iterator().next();
-        popupMenu.add(createNavigationMenuItem(navigationTarget, POPUP_MENU_HEADLINE));
+    private void addSingleNavigation(NavigationTarget navigationTarget) {
+        popupMenu.add(createNavigationMenuItem(navigationTarget, SHOW_IN_PROJECT_DESCRIPTOR));
     }
 
     private void addMultiNavigation(Set<NavigationTarget> navigationCandidates) {
         JMenu multiMenu = new JBMenu();
-        multiMenu.setText(POPUP_MENU_HEADLINE);
+        multiMenu.setText(SHOW_IN_PROJECT_DESCRIPTOR);
         for (NavigationTarget navigationTarget : navigationCandidates) {
             String descriptorPath = getRelativizedDescriptorPath(navigationTarget);
             multiMenu.add(createNavigationMenuItem(navigationTarget, descriptorPath + " " + (navigationTarget.getLineNumber() + 1)));
@@ -185,21 +195,21 @@ public class IssuesTree extends BaseTree {
     }
 
     private String getRelativizedDescriptorPath(NavigationTarget navigationTarget) {
-        String pathResult = navigationTarget.getVirtualFile().getName();
-        String projBasePath = mainProject.getBasePath();
-        if (projBasePath == null) {
-            return pathResult;
-        }
-
+        String pathResult = "";
         try {
+            VirtualFile descriptorVirtualFile = navigationTarget.getElement().getContainingFile().getVirtualFile();
+            pathResult = descriptorVirtualFile.getName();
+            String projBasePath = mainProject.getBasePath();
+            if (projBasePath == null) {
+                return pathResult;
+            }
             Path basePath = Paths.get(mainProject.getBasePath());
-            Path descriptorPath = Paths.get(navigationTarget.getVirtualFile().getPath());
+            Path descriptorPath = Paths.get(descriptorVirtualFile.getPath());
             pathResult = basePath.relativize(descriptorPath).toString();
-        } catch (InvalidPathException ex) {
+        } catch (InvalidPathException | PsiInvalidElementAccessException ex) {
             Logger log = Logger.getInstance(mainProject);
             log.error("Failed getting project-descriptor's path.", ex);
         }
-
         return pathResult;
     }
 
@@ -207,7 +217,49 @@ public class IssuesTree extends BaseTree {
         return new JBMenuItem(new AbstractAction(headLine) {
             @Override
             public void actionPerformed(ActionEvent e) {
-                new OpenFileDescriptor(mainProject, navigationTarget.getVirtualFile(), navigationTarget.getLineNumber(), 0).navigate(true);
+                if (!(navigationTarget.getElement() instanceof Navigatable)) {
+                    return;
+                }
+                Navigatable navigatable = (Navigatable) navigationTarget.getElement();
+                if (navigatable.canNavigate()) {
+                    navigatable.navigate(true);
+                }
+            }
+        });
+    }
+
+    private void addNodeExclusion(DependenciesTree nodeToExclude, Set<NavigationTarget> parentCandidates, DependenciesTree affectedNode) {
+        if (!ExclusionUtils.isExcludable(nodeToExclude, affectedNode)) {
+            return;
+        }
+        if (parentCandidates.size() > 1) {
+            addMultiExclusion(nodeToExclude, parentCandidates);
+        } else {
+            addSingleExclusion(nodeToExclude, parentCandidates.iterator().next());
+        }
+    }
+
+    private void addMultiExclusion(DependenciesTree nodeToExclude, Set<NavigationTarget> parentCandidates) {
+        JMenu multiMenu = new JBMenu();
+        multiMenu.setText(EXCLUDE_DEPENDENCY);
+        for (NavigationTarget parentCandidate : parentCandidates) {
+            Excludable excludable = ExclusionUtils.getExcludable(nodeToExclude, parentCandidate);
+            String descriptorPath = getRelativizedDescriptorPath(parentCandidate);
+            multiMenu.add(createExcludeMenuItem(excludable, descriptorPath + " " + (parentCandidate.getLineNumber() + 1)));
+        }
+        popupMenu.add(multiMenu);
+    }
+
+    private void addSingleExclusion(DependenciesTree nodeToExclude, NavigationTarget parentCandidate) {
+        Excludable excludable = ExclusionUtils.getExcludable(nodeToExclude, parentCandidate);
+        popupMenu.add(createExcludeMenuItem(excludable, EXCLUDE_DEPENDENCY));
+    }
+
+    private JBMenuItem createExcludeMenuItem(Excludable excludable, String headLine) {
+        return new JBMenuItem(new AbstractAction(headLine) {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                excludable.exclude(mainProject);
             }
         });
     }


### PR DESCRIPTION
Add the ability to exclude project's transitive dependencies from the Issues-Tree.
This first step applies only for Maven projects.

**Selecting the dependency to exclude:**
![image](https://user-images.githubusercontent.com/12187591/83727222-670fc200-a64d-11ea-9e6c-5f5d94fb9288.png)

**Issues-tree is refreshed after exclusion:**
![image](https://user-images.githubusercontent.com/12187591/83727066-2748da80-a64d-11ea-8471-b1ff8c959f2e.png)

**pom.xml with exclusion:**
![image](https://user-images.githubusercontent.com/12187591/83727077-2b74f800-a64d-11ea-8af7-f4c8e806c578.png)
