### PR TITLE
Bugfix - NoClassDefFoundError is thrown in IDEA 2020.1

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -21,6 +21,8 @@
     <idea-version since-build="183.3795.13"/>
     <depends>com.intellij.modules.lang</depends>
     <depends config-file="with-java.xml" optional="true">com.intellij.modules.java</depends>
+    <depends config-file="with-gradle.xml" optional="true">org.jetbrains.plugins.gradle</depends>
+    <depends config-file="with-maven.xml" optional="true">org.jetbrains.idea.maven</depends>
     <depends config-file="with-go.xml" optional="true">org.jetbrains.plugins.go</depends>
 
     <application-components>

--- a/src/main/resources/META-INF/with-java.xml
+++ b/src/main/resources/META-INF/with-java.xml
@@ -1,4 +1,1 @@
-<idea-plugin>
-    <depends config-file="with-gradle.xml" optional="true">org.jetbrains.plugins.gradle</depends>
-    <depends config-file="with-maven.xml" optional="true">org.jetbrains.idea.maven</depends>
-</idea-plugin>
+<idea-plugin/>


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jfrog-idea-plugin) passed. If this feature is not already covered by the tests, I added new tests.
-----

Resolves #74 