### PR TITLE
Bugfix - Broken navigation from tree to descriptor after applying tree-filters

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/scan/ScanManager.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ScanManager.java
@@ -199,7 +199,7 @@ public abstract class ScanManager extends ScanManagerBase {
         };
     }
 
-    private void runInspections() {
+    void runInspections() {
         PsiFile[] projectDescriptors = getProjectDescriptors();
         if (ArrayUtils.isEmpty(projectDescriptors)) {
             return;

--- a/src/main/java/com/jfrog/ide/idea/scan/ScanManagersFactory.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ScanManagersFactory.java
@@ -101,6 +101,16 @@ public class ScanManagersFactory {
     }
 
     /**
+     * Run inspections for all scan managers.
+     */
+    public void runInspectionsForAllScanManagers() {
+        NavigationService.clearNavigationMap(mainProject);
+        for (ScanManager scanManager : scanManagers.values()) {
+            scanManager.runInspections();
+        }
+    }
+
+    /**
      * Scan projects, create new ScanManagers and delete unnecessary ones.
      */
     public void refreshScanManagers() throws IOException {

--- a/src/main/java/com/jfrog/ide/idea/ui/issues/IssuesTree.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/issues/IssuesTree.java
@@ -2,6 +2,7 @@ package com.jfrog.ide.idea.ui.issues;
 
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.JBMenuItem;
 import com.intellij.openapi.ui.JBPopupMenu;
@@ -18,6 +19,7 @@ import com.jfrog.ide.idea.exclusion.ExclusionUtils;
 import com.jfrog.ide.idea.log.Logger;
 import com.jfrog.ide.idea.navigation.NavigationService;
 import com.jfrog.ide.idea.navigation.NavigationTarget;
+import com.jfrog.ide.idea.scan.ScanManagersFactory;
 import com.jfrog.ide.idea.ui.BaseTree;
 import com.jfrog.ide.idea.ui.filters.FilterManagerService;
 import com.jfrog.ide.idea.ui.listeners.IssuesTreeExpansionListener;
@@ -94,6 +96,7 @@ public class IssuesTree extends BaseTree {
         filteredRoot.setIssues(filteredRoot.processTreeIssues());
         appendProjectWhenReady(filteredRoot);
         calculateIssuesCount();
+        DumbService.getInstance(mainProject).smartInvokeLater(() -> ScanManagersFactory.getInstance(mainProject).runInspectionsForAllScanManagers());
     }
 
     @Override


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jfrog-idea-plugin) passed. If this feature is not already covered by the tests, I added new tests.
-----
