### PR TITLE
Support PAC proxy configuration

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/configuration/XrayServerConfigImpl.java
+++ b/src/main/java/com/jfrog/ide/idea/configuration/XrayServerConfigImpl.java
@@ -173,15 +173,25 @@ public class XrayServerConfigImpl implements XrayServerConfig {
         this.excludedPaths = excludedPaths;
     }
 
+    /**
+     * Get proxy configuration as configured under 'Appearance & Behavior' -> 'System Settings' -> 'HTTP Proxy'
+     *
+     * @param xrayUrl - The xray URL. The URL is necessary to determine whether to bypass proxy or to pick the relevant
+     *                proxy configuration for the Xray URL as configured in *.pac file.
+     * @return the proxy configuration as configured in IDEA settings.
+     */
     @Override
     public ProxyConfig getProxyConfForTargetUrl(String xrayUrl) {
         HttpConfigurable httpConfigurable = HttpConfigurable.getInstance();
         if (httpConfigurable.USE_PROXY_PAC) {
+            // 'Auto-detect proxy settings' option is selected
             return getProxyConfForTargetUrlUsingPac(httpConfigurable, xrayUrl);
         }
         if (httpConfigurable.isHttpProxyEnabledForUrl(xrayUrl)) {
+            // 'Manual proxy configuration' option is selected
             return getProxyConfForTargetUrlUsingManualConf(httpConfigurable);
         }
+        // 'No proxy' option is selected
         return null;
     }
 

--- a/src/test/java/com/jfrog/ide/idea/configuration/GetProxyConfForTargetUrlTest.java
+++ b/src/test/java/com/jfrog/ide/idea/configuration/GetProxyConfForTargetUrlTest.java
@@ -1,0 +1,100 @@
+package com.jfrog.ide.idea.configuration;
+
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase;
+import com.intellij.util.net.HttpConfigurable;
+import com.jfrog.ide.common.configuration.XrayServerConfig;
+import org.jfrog.client.http.model.ProxyConfig;
+
+import java.io.File;
+import java.net.PasswordAuthentication;
+import java.net.URL;
+
+/**
+ * @author yahavi
+ */
+public class GetProxyConfForTargetUrlTest extends LightJavaCodeInsightFixtureTestCase {
+
+    private final XrayServerConfig xrayServerConfig = new XrayServerConfigImpl();
+    private HttpConfigurable httpConfigurable;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        // Disable all proxies
+        httpConfigurable = HttpConfigurable.getInstance();
+        httpConfigurable.USE_HTTP_PROXY = false;
+        httpConfigurable.USE_PROXY_PAC = false;
+
+        // Set PAC URL
+        URL pacUrl = getClass().getClassLoader().getResource("proxy/proxy.pac");
+        assertNotNull(pacUrl);
+        File pacFile = new File(pacUrl.getFile());
+        httpConfigurable.PAC_URL = pacFile.getAbsolutePath();
+        httpConfigurable.USE_PAC_URL = true;
+    }
+
+    /**
+     * Check that we get null proxy configuration if proxy is not defined.
+     */
+    public void testProxyNotConfigured() {
+        ProxyConfig proxyConfig = xrayServerConfig.getProxyConfForTargetUrl("https://1.2.3.4");
+        assertNull(proxyConfig);
+    }
+
+    /**
+     * Check manual proxy configuration.
+     */
+    public void testManuallyConfiguredProxy() {
+        // Set manual proxy configuration
+        httpConfigurable.USE_HTTP_PROXY = true;
+        httpConfigurable.PROXY_HOST = "proxyHost.org";
+        httpConfigurable.PROXY_PORT = 8888;
+        httpConfigurable.PROXY_AUTHENTICATION = true;
+        httpConfigurable.setProxyLogin("admin");
+        httpConfigurable.setPlainProxyPassword("password");
+
+        // Get proxy config for https://1.2.3.4
+        ProxyConfig proxyConfig = xrayServerConfig.getProxyConfForTargetUrl("https://1.2.3.4");
+        assertNotNull(proxyConfig);
+
+        // Check proxy config
+        assertEquals("proxyHost.org", proxyConfig.getHost());
+        assertEquals(8888, proxyConfig.getPort());
+        assertEquals("admin", proxyConfig.getUsername());
+        assertEquals("password", proxyConfig.getPassword());
+    }
+
+    /**
+     * Test proxy configuration using PAC file.
+     * The PAC file is configured to return "proxyPacHost.org:8888" for "https://1.2.3.4" URL.
+     */
+    public void testPacConfiguredProxy() {
+        // Set PAC proxy configuration
+        httpConfigurable.USE_PROXY_PAC = true;
+        PasswordAuthentication passwordAuthentication = new PasswordAuthentication("admin", "password".toCharArray());
+        httpConfigurable.putGenericPassword("proxyPacHost.org", 8888, passwordAuthentication, true);
+
+        // Get proxy config for https://1.2.3.4
+        ProxyConfig proxyConfig = xrayServerConfig.getProxyConfForTargetUrl("https://1.2.3.4");
+        assertNotNull(proxyConfig);
+
+        // Check proxy config
+        assertEquals("proxyPacHost.org", proxyConfig.getHost());
+        assertEquals(8888, proxyConfig.getPort());
+        assertEquals("admin", proxyConfig.getUsername());
+        assertEquals("password", proxyConfig.getPassword());
+    }
+
+    /**
+     * Test proxy configuration using PAC file.
+     * The PAC file is configured to return "DIRECT" for "https://1.2.3.5" URL.
+     */
+    public void testPacConfiguredNoProxy() {
+        // Set PAC proxy configuration
+        httpConfigurable.USE_PROXY_PAC = true;
+
+        // Assert no proxy config for https://1.2.3.5
+        ProxyConfig proxyConfig = xrayServerConfig.getProxyConfForTargetUrl("https://1.2.3.5");
+        assertNull(proxyConfig);
+    }
+}

--- a/src/test/resources/proxy/proxy.pac
+++ b/src/test/resources/proxy/proxy.pac
@@ -1,0 +1,6 @@
+function FindProxyForURL(url, host) {
+    if (url === "https://1.2.3.5") {
+        return "DIRECT"
+    }
+    return "PROXY proxyPacHost.org:8888; PROXY proxyPacSecondHost.org:8888";
+}


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jfrog-idea-plugin) passed. If this feature is not already covered by the tests, I added new tests.
-----

Support proxy configured by PAC files.