### PR TITLE
Maven - allow duplicated dependencies in same modules

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/scan/MavenScanManager.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/MavenScanManager.java
@@ -148,6 +148,7 @@ public class MavenScanManager extends ScanManager {
     }
 
     private void updateChildrenNodes(DependenciesTree parentNode, MavenArtifactNode mavenArtifactNode, Set<String> added, boolean setScopes) {
+        // This set is used to disallow duplications between a node and its ancestors
         final Set<String> addedInSubTree = Sets.newHashSet(added);
         MavenArtifact mavenArtifact = mavenArtifactNode.getArtifact();
         DependenciesTree currentNode = new DependenciesTree(mavenArtifact.getDisplayStringSimple());

--- a/src/main/java/com/jfrog/ide/idea/scan/MavenScanManager.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/MavenScanManager.java
@@ -148,6 +148,7 @@ public class MavenScanManager extends ScanManager {
     }
 
     private void updateChildrenNodes(DependenciesTree parentNode, MavenArtifactNode mavenArtifactNode, Set<String> added, boolean setScopes) {
+        final Set<String> addedInSubTree = Sets.newHashSet(added);
         MavenArtifact mavenArtifact = mavenArtifactNode.getArtifact();
         DependenciesTree currentNode = new DependenciesTree(mavenArtifact.getDisplayStringSimple());
         if (setScopes) {
@@ -156,8 +157,8 @@ public class MavenScanManager extends ScanManager {
         populateDependenciesTreeNode(currentNode);
         mavenArtifactNode.getDependencies()
                 .stream()
-                .filter(dependencyTree -> added.add(dependencyTree.getArtifact().getDisplayStringForLibraryName()))
-                .forEach(childrenArtifactNode -> updateChildrenNodes(currentNode, childrenArtifactNode, added, false));
+                .filter(dependencyTree -> addedInSubTree.add(dependencyTree.getArtifact().getDisplayStringForLibraryName()))
+                .forEach(childrenArtifactNode -> updateChildrenNodes(currentNode, childrenArtifactNode, addedInSubTree, false));
         parentNode.add(currentNode);
     }
 


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jfrog-idea-plugin) passed. If this feature is not already covered by the tests, I added new tests.
-----
Partially resolved #106 

Currently duplicated Maven dependencies in the same module are not shows in the dependency tree.
This PR disallows this only 2 dependencies are descendants (to avoid loops).
Before:
![Screen Shot 2021-02-07 at 11 46 38](https://user-images.githubusercontent.com/11367982/107146187-32c47200-694f-11eb-8afd-cf0b79ebb793.png)

After:
![Screen Shot 2021-02-07 at 12 08 13](https://user-images.githubusercontent.com/11367982/107146197-42dc5180-694f-11eb-8a67-bca7300976be.png)
