### PR TITLE
Increase max RAM to 2G in development sandbox

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,10 @@ intellij {
     updateSinceUntilBuild = false
 }
 
+runIde {
+    jvmArgs '-Xmx2G'
+}
+
 repositories {
     mavenLocal()
     maven {


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jfrog-idea-plugin) passed. If this feature is not already covered by the tests, I added new tests.
-----

In the plugin development mode, using the `runIdea` Gradle task start a new IntelliJ window with a small amount of memory. Let's increase it to 2G.