### PR TITLE
Fix configuration tests in Windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,8 @@ repositories {
 dependencies {
     implementation group: 'com.jfrog.ide', name: 'ide-plugins-common', version: '1.4.x-SNAPSHOT'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.11'
-    testImplementation group: 'com.github.stefanbirkner', name: 'system-lambda', version: '1.1.1'
+    testImplementation "org.mockito:mockito-core:3.9.0"
+    testImplementation "org.mockito:mockito-inline:3.9.0"
 }
 
 test {

--- a/src/test/java/com/jfrog/ide/idea/configuration/ConfigurationTest.java
+++ b/src/test/java/com/jfrog/ide/idea/configuration/ConfigurationTest.java
@@ -1,9 +1,11 @@
 package com.jfrog.ide.idea.configuration;
 
-import com.github.stefanbirkner.systemlambda.SystemLambda;
 import com.intellij.credentialStore.Credentials;
 import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase;
+import com.intellij.util.EnvironmentUtil;
 import com.jfrog.ide.idea.ui.configuration.Utils;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import static com.jfrog.ide.idea.configuration.ServerConfigImpl.*;
 
@@ -114,12 +116,14 @@ public class ConfigurationTest extends LightJavaCodeInsightFixtureTestCase {
     /**
      * Test set server config from environment variables.
      */
-    public void testSetServerConfigFromEnv() throws Exception {
-        SystemLambda.withEnvironmentVariable(PLATFORM_URL_ENV, "https://tython.jfrog.io")
-                .and(XRAY_URL_ENV, "https://tython.jfrog.io/xray")
-                .and(ARTIFACTORY_URL_ENV, "https://tython.jfrog.io/artifactory")
-                .and(USERNAME_ENV, "leia")
-                .and(PASSWORD_ENV, "princess").execute(() -> {
+    public void testSetServerConfigFromEnv() {
+        try (MockedStatic<EnvironmentUtil> mockController = Mockito.mockStatic(EnvironmentUtil.class)) {
+            mockController.when(() -> EnvironmentUtil.getValue(PLATFORM_URL_ENV)).thenReturn("https://tython.jfrog.io");
+            mockController.when(() -> EnvironmentUtil.getValue(XRAY_URL_ENV)).thenReturn("https://tython.jfrog.io/xray");
+            mockController.when(() -> EnvironmentUtil.getValue(ARTIFACTORY_URL_ENV)).thenReturn("https://tython.jfrog.io/artifactory");
+            mockController.when(() -> EnvironmentUtil.getValue(USERNAME_ENV)).thenReturn("leia");
+            mockController.when(() -> EnvironmentUtil.getValue(PASSWORD_ENV)).thenReturn("princess");
+
             // Create overriding server config
             GlobalSettings globalSettings = new GlobalSettings();
             ServerConfigImpl overrideServerConfig = createServerConfig(false, false);
@@ -139,17 +143,18 @@ public class ConfigurationTest extends LightJavaCodeInsightFixtureTestCase {
             assertEquals(CONNECTION_RETRIES, actualServerConfig.getConnectionRetries());
             assertEquals(CONNECTION_TIMEOUT, actualServerConfig.getConnectionTimeout());
             assertEquals(EXCLUDED_PATHS, actualServerConfig.getExcludedPaths());
-        });
+        }
     }
 
     /**
      * Test set server config from JFROG_IDE_URL legacy environment variable.
      */
     @SuppressWarnings("deprecation")
-    public void testSetServerConfigFromLegacyEnv() throws Exception {
-        SystemLambda.withEnvironmentVariable(LEGACY_XRAY_URL_ENV, "https://tython.jfrog.io/xray")
-                .and(USERNAME_ENV, "leia")
-                .and(PASSWORD_ENV, "princess").execute(() -> {
+    public void testSetServerConfigFromLegacyEnv() {
+        try (MockedStatic<EnvironmentUtil> mockController = Mockito.mockStatic(EnvironmentUtil.class)) {
+            mockController.when(() -> EnvironmentUtil.getValue(LEGACY_XRAY_URL_ENV)).thenReturn("https://tython.jfrog.io/xray");
+            mockController.when(() -> EnvironmentUtil.getValue(USERNAME_ENV)).thenReturn("leia");
+            mockController.when(() -> EnvironmentUtil.getValue(PASSWORD_ENV)).thenReturn("princess");
             // Create overriding server config
             GlobalSettings globalSettings = new GlobalSettings();
             ServerConfigImpl overrideServerConfig = createServerConfig(false, false);
@@ -169,7 +174,7 @@ public class ConfigurationTest extends LightJavaCodeInsightFixtureTestCase {
             assertEquals(CONNECTION_RETRIES, actualServerConfig.getConnectionRetries());
             assertEquals(CONNECTION_TIMEOUT, actualServerConfig.getConnectionTimeout());
             assertEquals(EXCLUDED_PATHS, actualServerConfig.getExcludedPaths());
-        });
+        }
     }
 
     /**
@@ -177,13 +182,14 @@ public class ConfigurationTest extends LightJavaCodeInsightFixtureTestCase {
      * This time, the URL provided could not be resolved to the platform URL.
      */
     @SuppressWarnings("deprecation")
-    public void testSetServerConfigFromXrayLegacyEnv() throws Exception {
-        SystemLambda.withEnvironmentVariable(LEGACY_XRAY_URL_ENV, "https://tython-xray.jfrog.io")
-                .and(PLATFORM_URL_ENV, "")
-                .and(ARTIFACTORY_URL_ENV, "")
-                .and(XRAY_URL_ENV, "")
-                .and(USERNAME_ENV, "leia")
-                .and(PASSWORD_ENV, "princess").execute(() -> {
+    public void testSetServerConfigFromXrayLegacyEnv() {
+        try (MockedStatic<EnvironmentUtil> mockController = Mockito.mockStatic(EnvironmentUtil.class)) {
+            mockController.when(() -> EnvironmentUtil.getValue(LEGACY_XRAY_URL_ENV)).thenReturn("https://tython-xray.jfrog.io");
+            mockController.when(() -> EnvironmentUtil.getValue(PLATFORM_URL_ENV)).thenReturn("");
+            mockController.when(() -> EnvironmentUtil.getValue(ARTIFACTORY_URL_ENV)).thenReturn("");
+            mockController.when(() -> EnvironmentUtil.getValue(USERNAME_ENV)).thenReturn("leia");
+            mockController.when(() -> EnvironmentUtil.getValue(PASSWORD_ENV)).thenReturn("princess");
+
             // Create overriding server config
             GlobalSettings globalSettings = new GlobalSettings();
             ServerConfigImpl overrideServerConfig = createServerConfig(false, false);
@@ -203,7 +209,7 @@ public class ConfigurationTest extends LightJavaCodeInsightFixtureTestCase {
             assertEquals(CONNECTION_RETRIES, actualServerConfig.getConnectionRetries());
             assertEquals(CONNECTION_TIMEOUT, actualServerConfig.getConnectionTimeout());
             assertEquals(EXCLUDED_PATHS, actualServerConfig.getExcludedPaths());
-        });
+        }
     }
 
     /**


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jfrog-idea-plugin) passed. If this feature is not already covered by the tests, I added new tests.
-----

"testSetServerConfigFromEnv", "testSetServerConfigFromLegacyEnv", and "testSetServerConfigFromXrayLegacyEnv" are tests that check the functionality of loading credentials from environment variables.

The operational code reads the environment variables using Intellij's `EnvironmentUtil.getValue()`. Probably for performance-wise in Windows, the environment map is stored in a static variable that can't be changed. Changing the system environment variables won't take effect in this case, which is the reason why the test failed.

Therefore the only way to test this functionality is using mocks.