### PR TITLE
Support slash in build name

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/ci/CiManager.java
+++ b/src/main/java/com/jfrog/ide/idea/ci/CiManager.java
@@ -126,9 +126,8 @@ public class CiManager extends CiManagerBase {
      * @return the build general info or null
      */
     public BuildGeneralInfo getBuildGeneralInfo(String buildIdentifier) {
-        String[] buildSplit = buildIdentifier.split("/");
-        String buildName = buildSplit[0];
-        String buildNumber = buildSplit[1];
+        String buildName = StringUtils.substringBeforeLast(buildIdentifier, "/");
+        String buildNumber = StringUtils.substringAfterLast(buildIdentifier, "/");
         return (BuildGeneralInfo) root.getChildren().stream()
                 .map(DependencyTree::getGeneralInfo)
                 .filter(generalInfo -> StringUtils.equals(buildName, generalInfo.getArtifactId()))


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jfrog-idea-plugin) passed. If this feature is not already covered by the tests, I added new tests.
-----

Fix an issue whereby build names contain "/", parsed incorrectly.
For example, when the build identifier is "declarative/dockerPull test/1".
Before fix: 
Build name: declarative
Build number: dockerPull test/1

After fix:
Build name: declarative/dockerPull test
Build number: 1