### PR TITLE
Bugfix - saveSettings may occur before IntelliJ finishes loading

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/configuration/GlobalSettings.java
+++ b/src/main/java/com/jfrog/ide/idea/configuration/GlobalSettings.java
@@ -19,6 +19,7 @@
  */
 package com.jfrog.ide.idea.configuration;
 
+import com.intellij.openapi.application.Application;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.State;
@@ -200,7 +201,8 @@ public final class GlobalSettings implements PersistentStateComponent<GlobalSett
         this.serverConfig.setUsername(serverConfig.getUsername());
         this.serverConfig.setPassword(serverConfig.getPassword());
         this.serverConfig.addCredentialsToPasswordSafe();
-        ApplicationManager.getApplication().saveSettings();
+        Application application = ApplicationManager.getApplication();
+        application.invokeLater(application::saveSettings);
     }
 
     /**


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jfrog-idea-plugin) passed. If this feature is not already covered by the tests, I added new tests.
-----

Should fix this issue: https://youtrack.jetbrains.com/issue/IDEA-271019

The following error message logged on IntelliJ startup:
> Should be called at least in the state COMPONENTS_LOADED, the current state is: CONFIGURATION_STORE_INITIALIZED
Current violators count: 1