### PR TITLE
Fix Gradle inspection

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -26,6 +26,7 @@
     <idea-version since-build="203.5419.21"/>
     <depends>com.intellij.modules.lang</depends>
     <depends config-file="with-java.xml" optional="true">com.intellij.modules.java</depends>
+    <depends config-file="with-gradle.xml" optional="true">com.intellij.gradle</depends>
     <depends config-file="with-groovy.xml" optional="true">org.intellij.groovy</depends>
     <depends config-file="with-kotlin.xml" optional="true">org.jetbrains.kotlin</depends>
     <depends config-file="with-maven.xml" optional="true">org.jetbrains.idea.maven</depends>

--- a/src/main/resources/META-INF/with-gradle.xml
+++ b/src/main/resources/META-INF/with-gradle.xml
@@ -1,0 +1,1 @@
+<idea-plugin/>

--- a/src/main/resources/META-INF/with-kotlin.xml
+++ b/src/main/resources/META-INF/with-kotlin.xml
@@ -1,5 +1,4 @@
 <idea-plugin>
-    <depends>org.jetbrains.kotlin</depends>
     <extensions defaultExtensionNs="com.intellij">
         <localInspection language="kotlin"
                          displayName="Show in dependency tree"


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----

Fix the following exception:
> java.lang.NoClassDefFoundError: org/jetbrains/plugins/gradle/settings/GradleSettings
	at com.jfrog.ide.idea.inspections.GradleInspection.getGradleModules(GradleInspection.java:55)
	at com.jfrog.ide.idea.inspections.GradleInspection.getModules(GradleInspection.java:39)
	at com.jfrog.ide.idea.inspections.AbstractInspection.getDependencies(AbstractInspection.java:160)
	at com.jfrog.ide.idea.inspections.AbstractInspection.visitElement(AbstractInspection.java:50)
	at com.jfrog.ide.idea.inspections.GradleGroovyInspection$1.visitLiteralExpression(GradleGroovyInspection.java:38)