### PR TITLE
Set the target component of the ActionToolbar

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/ui/AbstractJFrogToolWindow.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/AbstractJFrogToolWindow.java
@@ -145,6 +145,7 @@ public abstract class AbstractJFrogToolWindow extends SimpleToolWindowPanel {
 
     JPanel createJFrogToolbar(ActionGroup actionGroup) {
         ActionToolbar actionToolbar = ActionManager.getInstance().createActionToolbar("JFrog toolbar", actionGroup, true);
+        actionToolbar.setTargetComponent(this);
         JPanel toolbarPanel = new JBPanel<>(new FlowLayout(FlowLayout.LEFT, 0, 0));
         toolbarPanel.add(actionToolbar.getComponent());
         return toolbarPanel;


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----

This PR should resolve the warning message presented in #145:
> 2021-09-21 08:09:37,604 [ 68772] WARN - nSystem.impl.ActionToolbarImpl - 'JFrog toolbar' toolbar by default uses any focused component to update its actions. Toolbar actions that need local UI context would be incorrectly disabled. Please call toolbar.setTargetComponent() explicitly.