### PR TITLE
Send the excluded paths to the GoTreeBuilder

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/scan/GoScanManager.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/GoScanManager.java
@@ -10,6 +10,7 @@ import com.intellij.util.EnvironmentUtil;
 import com.jfrog.ide.common.go.GoTreeBuilder;
 import com.jfrog.ide.common.scan.ComponentPrefix;
 import com.jfrog.ide.common.scan.ScanLogic;
+import com.jfrog.ide.idea.configuration.GlobalSettings;
 import com.jfrog.ide.idea.inspections.GoInspection;
 import com.jfrog.ide.idea.ui.ComponentsTree;
 import com.jfrog.ide.idea.ui.filters.filtermanager.ConsistentFilterManager;
@@ -29,10 +30,10 @@ public class GoScanManager extends ScanManager {
      *                 like {@link ConsistentFilterManager} and {@link ComponentsTree}.
      * @param basePath - The go.mod directory.
      */
-    GoScanManager(Project project, String basePath, ScanLogic logic) throws IOException {
+    GoScanManager(Project project, String basePath, ScanLogic logic) {
         super(project, basePath, ComponentPrefix.GO, logic);
         getLog().info("Found Go project: " + getProjectName());
-        goTreeBuilder = new GoTreeBuilder(Paths.get(basePath), EnvironmentUtil.getEnvironmentMap(), getLog());
+        goTreeBuilder = new GoTreeBuilder(Paths.get(basePath), EnvironmentUtil.getEnvironmentMap(), getLog(), GlobalSettings.getInstance().getServerConfig().getExcludedPaths());
         subscribeLaunchDependencyScanOnFileChangedEvents("go.sum");
     }
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----

Depends on https://github.com/jfrog/ide-plugins-common/pull/48
Send the excluded paths to the GoTreeBuilder to allow it to ignore `go.mod` files which should not be scanned.