### PR TITLE
Fix go executable path

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/utils/GoUtils.java
+++ b/src/main/java/com/jfrog/ide/idea/utils/GoUtils.java
@@ -8,6 +8,7 @@ import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.project.Project;
 import org.apache.commons.lang3.StringUtils;
 
+import java.io.File;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
@@ -42,6 +43,8 @@ public class GoUtils {
         });
         String goExecutablePath = GoSdkUtil.retrieveEnvironmentPathForGo(project, null);
         if (StringUtils.isNotBlank(goExecutablePath)) {
+            // The returned value may contain more than one path, seperated by ':' or ';'
+            goExecutablePath = StringUtils.substringBefore(goExecutablePath, File.pathSeparator);
             return Paths.get(goExecutablePath, "go").toString();
         }
         return null;


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----

Fix unreleased bug introduced in https://github.com/jfrog/jfrog-idea-plugin/pull/155

The returned Go executable path from `GoSdkUtil.retrieveEnvironmentPathForGo(project, null)` may contain more than one path. The structure is like the system environment path.
Therefore, we may use the first path as the Go executable path.