### PR TITLE
Trigger refresh scan managers on configuration change

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/events/ApplicationEvents.java
+++ b/src/main/java/com/jfrog/ide/idea/events/ApplicationEvents.java
@@ -10,7 +10,6 @@ import com.intellij.util.messages.Topic;
 public interface ApplicationEvents {
     Topic<ApplicationEvents> ON_CONFIGURATION_DETAILS_CHANGE = Topic.create("Configuration details changed", ApplicationEvents.class);
     Topic<ApplicationEvents> ON_BUILDS_CONFIGURATION_CHANGE = Topic.create("Builds configuration changed", ApplicationEvents.class);
-    Topic<ApplicationEvents> ON_EXCLUDED_PATHS_CHANGE = Topic.create("Excluded paths changed", ApplicationEvents.class);
     Topic<ApplicationEvents> ON_SCAN_FILTER_CHANGE = Topic.create("Scan issues changed", ApplicationEvents.class);
     Topic<ApplicationEvents> ON_CI_FILTER_CHANGE = Topic.create("CI issues changed", ApplicationEvents.class);
 

--- a/src/main/java/com/jfrog/ide/idea/scan/ScanManager.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ScanManager.java
@@ -21,13 +21,11 @@ import com.intellij.openapi.vfs.newvfs.BulkFileListener;
 import com.intellij.openapi.vfs.newvfs.events.VFileEvent;
 import com.intellij.psi.PsiFile;
 import com.intellij.util.messages.MessageBus;
-import com.intellij.util.messages.MessageBusConnection;
 import com.jfrog.ide.common.log.ProgressIndicator;
 import com.jfrog.ide.common.scan.ComponentPrefix;
 import com.jfrog.ide.common.scan.ScanManagerBase;
 import com.jfrog.ide.common.utils.ProjectsMap;
 import com.jfrog.ide.idea.configuration.GlobalSettings;
-import com.jfrog.ide.idea.events.ApplicationEvents;
 import com.jfrog.ide.idea.events.ProjectEvents;
 import com.jfrog.ide.idea.log.Logger;
 import com.jfrog.ide.idea.log.ProgressIndicatorImpl;
@@ -74,7 +72,6 @@ public abstract class ScanManager extends ScanManagerBase {
         super(basePath, Logger.getInstance(), GlobalSettings.getInstance().getServerConfig(), prefix);
         this.project = project;
         this.basePath = basePath;
-        registerOnChangeHandlers();
     }
 
     /**
@@ -191,11 +188,6 @@ public abstract class ScanManager extends ScanManagerBase {
                 DaemonCodeAnalyzer.getInstance(project).restart(descriptor);
             }
         }
-    }
-
-    private void registerOnChangeHandlers() {
-        MessageBusConnection busConnection = ApplicationManager.getApplication().getMessageBus().connect();
-        busConnection.subscribe(ApplicationEvents.ON_CONFIGURATION_DETAILS_CHANGE, this::asyncScanAndUpdateResults);
     }
 
     /**

--- a/src/main/java/com/jfrog/ide/idea/scan/ScanManagersFactory.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ScanManagersFactory.java
@@ -65,7 +65,7 @@ public class ScanManagersFactory {
         MessageBusConnection busConnection = ApplicationManager.getApplication().getMessageBus().connect();
         // When the excluded paths change, scan managers should be created or deleted.
         // Therefore, we run startScan() which recreates the scan managers on refreshScanManagers().
-        busConnection.subscribe(ApplicationEvents.ON_EXCLUDED_PATHS_CHANGE, () -> startScan(true));
+        busConnection.subscribe(ApplicationEvents.ON_CONFIGURATION_DETAILS_CHANGE, () -> startScan(true));
     }
 
     /**

--- a/src/main/java/com/jfrog/ide/idea/ui/configuration/JFrogGlobalConfiguration.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/configuration/JFrogGlobalConfiguration.java
@@ -245,14 +245,9 @@ public class JFrogGlobalConfiguration implements Configurable, Configurable.NoSc
     @Override
     public void apply() {
         GlobalSettings globalSettings = GlobalSettings.getInstance();
-        boolean excludedPathsChanged = !StringUtils.equals(serverConfig.getExcludedPaths(), globalSettings.getServerConfig().getExcludedPaths());
         globalSettings.updateConfig(serverConfig);
         MessageBus messageBus = ApplicationManager.getApplication().getMessageBus();
-        if (excludedPathsChanged) {
-            messageBus.syncPublisher(ApplicationEvents.ON_EXCLUDED_PATHS_CHANGE).update();
-        } else {
-            messageBus.syncPublisher(ApplicationEvents.ON_CONFIGURATION_DETAILS_CHANGE).update();
-        }
+        messageBus.syncPublisher(ApplicationEvents.ON_CONFIGURATION_DETAILS_CHANGE).update();
         connectionResults.setText("");
         loadConfig();
     }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----

Followup https://github.com/jfrog/jfrog-idea-plugin/pull/158#discussion_r726032570
Refresh scan managers and trigger a quick scan after a configuration change.
The reason for this change is a change in Xray credential or in the JFrog project may change the violations.