### PR TITLE
Improve global configuration page

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/ui/configuration/JFrogGlobalConfiguration.form
+++ b/src/main/java/com/jfrog/ide/idea/ui/configuration/JFrogGlobalConfiguration.form
@@ -313,7 +313,7 @@
             </constraints>
             <properties>
               <enabled value="false"/>
-              <text value="    Optionally use the Project field to allow the security and license compliance information displayed in"/>
+              <text value="    Optionally use the project key field to allow the security and license compliance information displayed"/>
             </properties>
           </component>
           <component id="ed918" class="javax.swing.JLabel">
@@ -324,7 +324,7 @@
             </constraints>
             <properties>
               <enabled value="false"/>
-              <text value="    IntelliJ IDEA, to reflect the Security Policies required by your organization. This is done as follows:"/>
+              <text value="    in IntelliJ IDEA, to reflect the security policies required by your organization. This is done as follows:"/>
             </properties>
           </component>
           <component id="f96a4" class="com.intellij.ui.HyperlinkLabel" binding="projectInstructions">
@@ -370,7 +370,7 @@
               <grid row="10" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <text value="    Project name"/>
+              <text value="    Project key"/>
             </properties>
           </component>
           <component id="b50f7" class="com.intellij.ui.TitledSeparator">
@@ -386,7 +386,7 @@
               <grid row="9" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <text value="JFrog Project"/>
+              <text value="Scan Policies"/>
             </properties>
           </component>
           <component id="52b21" class="com.intellij.ui.TitledSeparator">

--- a/src/main/java/com/jfrog/ide/idea/ui/configuration/JFrogGlobalConfiguration.form
+++ b/src/main/java/com/jfrog/ide/idea/ui/configuration/JFrogGlobalConfiguration.form
@@ -1,312 +1,463 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.jfrog.ide.idea.ui.configuration.JFrogGlobalConfiguration">
-  <grid id="27dc6" binding="config" layout-manager="GridLayoutManager" row-count="20" column-count="15" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-    <margin top="0" left="0" bottom="0" right="0"/>
+  <tabbedpane id="7b91a">
     <constraints>
-      <xy x="20" y="20" width="1317" height="626"/>
+      <xy x="20" y="170" width="743" height="576"/>
     </constraints>
-    <properties/>
+    <properties>
+      <autoscrolls value="false"/>
+      <doubleBuffered value="true"/>
+      <enabled value="true"/>
+      <minimumSize width="0" height="0"/>
+      <opaque value="true"/>
+      <preferredSize width="0" height="0"/>
+      <requestFocusEnabled value="false"/>
+      <tabLayoutPolicy value="0"/>
+      <tabPlacement value="1"/>
+    </properties>
     <border type="none"/>
     <children>
-      <component id="d1e80" class="javax.swing.JLabel">
+      <grid id="b0c38" binding="connectionDetails" layout-manager="GridLayoutManager" row-count="13" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="3" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
-            <preferred-size width="133" height="16"/>
-          </grid>
+          <tabbedpane title="Connection Details"/>
         </constraints>
         <properties>
-          <text value="JFrog platform URL"/>
-          <toolTipText value=""/>
+          <doubleBuffered value="true"/>
+          <minimumSize width="0" height="0"/>
+          <preferredSize width="0" height="0"/>
         </properties>
-      </component>
-      <component id="c1160" class="com.intellij.ui.components.JBTextField" binding="platformUrl">
+        <border type="none"/>
+        <children>
+          <component id="9b2da" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                <preferred-size width="133" height="16"/>
+              </grid>
+            </constraints>
+            <properties>
+              <text value="JFrog platform URL"/>
+              <toolTipText value=""/>
+            </properties>
+          </component>
+          <component id="99f62" class="com.intellij.ui.components.JBTextField" binding="platformUrl">
+            <constraints>
+              <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="1" indent="0" use-parent-layout="false">
+                <preferred-size width="133" height="30"/>
+              </grid>
+            </constraints>
+            <properties>
+              <text value=""/>
+              <toolTipText value="Example: http://myjfrog.acme.org/xray"/>
+            </properties>
+          </component>
+          <component id="a8f26" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                <preferred-size width="133" height="16"/>
+              </grid>
+            </constraints>
+            <properties>
+              <text value="Username"/>
+            </properties>
+          </component>
+          <component id="59d39" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                <preferred-size width="133" height="16"/>
+              </grid>
+            </constraints>
+            <properties>
+              <text value="Password"/>
+            </properties>
+          </component>
+          <component id="d208" class="com.intellij.ui.components.JBTextField" binding="username">
+            <constraints>
+              <grid row="6" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                <preferred-size width="133" height="0"/>
+              </grid>
+            </constraints>
+            <properties>
+              <text value=""/>
+            </properties>
+          </component>
+          <component id="62866" class="javax.swing.JButton" binding="testConnectionButton" default-binding="true">
+            <constraints>
+              <grid row="11" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false">
+                <preferred-size width="133" height="30"/>
+              </grid>
+            </constraints>
+            <properties>
+              <text value="Test connection"/>
+            </properties>
+          </component>
+          <component id="344ac" class="com.intellij.ui.components.JBLabel" binding="connectionResults">
+            <constraints>
+              <grid row="11" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="1" indent="0" use-parent-layout="false">
+                <preferred-size width="133" height="0"/>
+              </grid>
+            </constraints>
+            <properties>
+              <enabled value="true"/>
+              <font name="Courier 10 Pitch"/>
+              <horizontalAlignment value="10"/>
+              <text value=""/>
+            </properties>
+          </component>
+          <component id="4d996" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="9" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                <preferred-size width="133" height="16"/>
+              </grid>
+            </constraints>
+            <properties>
+              <text value="JFrog Xray URL"/>
+              <toolTipText value=""/>
+            </properties>
+          </component>
+          <component id="ed5f3" class="javax.swing.JCheckBox" binding="setRtAndXraySeparately" default-binding="true">
+            <constraints>
+              <grid row="8" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                <preferred-size width="133" height="21"/>
+              </grid>
+            </constraints>
+            <properties>
+              <text value="Set Artifactory and Xray URLs separately"/>
+            </properties>
+          </component>
+          <component id="f92ad" class="com.intellij.ui.components.JBTextField" binding="xrayUrl">
+            <constraints>
+              <grid row="9" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                <preferred-size width="133" height="30"/>
+              </grid>
+            </constraints>
+            <properties>
+              <text value=""/>
+              <toolTipText value="Example: http://myjfrog.acme.org/xray"/>
+            </properties>
+          </component>
+          <component id="a6009" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="10" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                <preferred-size width="133" height="16"/>
+              </grid>
+            </constraints>
+            <properties>
+              <text value="JFrog Artifactory URL"/>
+              <toolTipText value=""/>
+            </properties>
+          </component>
+          <component id="f6921" class="com.intellij.ui.components.JBTextField" binding="artifactoryUrl">
+            <constraints>
+              <grid row="10" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                <preferred-size width="133" height="30"/>
+              </grid>
+            </constraints>
+            <properties>
+              <horizontalAlignment value="10"/>
+              <text value=""/>
+              <toolTipText value="Example: http://myjfrog.acme.org/xray"/>
+            </properties>
+          </component>
+          <component id="cad10" class="com.intellij.ui.components.JBLabel" binding="artifactoryConnectionResults">
+            <constraints>
+              <grid row="10" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                <preferred-size width="0" height="0"/>
+              </grid>
+            </constraints>
+            <properties>
+              <text value=""/>
+            </properties>
+          </component>
+          <component id="5bc72" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                <preferred-size width="133" height="16"/>
+              </grid>
+            </constraints>
+            <properties>
+              <enabled value="false"/>
+              <text value="JFROG_IDE_PASSWORD environment variables."/>
+            </properties>
+          </component>
+          <component id="38b32" class="com.intellij.ui.components.JBPasswordField" binding="password">
+            <constraints>
+              <grid row="7" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                <preferred-size width="133" height="30"/>
+              </grid>
+            </constraints>
+            <properties/>
+          </component>
+          <component id="9555" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                <preferred-size width="133" height="16"/>
+              </grid>
+            </constraints>
+            <properties>
+              <enabled value="false"/>
+              <foreground color="-4473925"/>
+              <text value="Load connection details from the JFROG_IDE_URL, JFROG_IDE_USERNAME and"/>
+            </properties>
+          </component>
+          <component id="23de2" class="com.intellij.ui.components.JBCheckBox" binding="connectionDetailsFromEnv">
+            <constraints>
+              <grid row="1" column="0" row-span="2" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Load connection details from environment variables"/>
+            </properties>
+          </component>
+          <component id="5d86b" class="com.intellij.ui.components.JBLabel" binding="xrayConnectionResults">
+            <constraints>
+              <grid row="9" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value=""/>
+            </properties>
+          </component>
+          <hspacer id="954a4">
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+            </constraints>
+          </hspacer>
+          <vspacer id="d7093">
+            <constraints>
+              <grid row="12" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+            </constraints>
+          </vspacer>
+        </children>
+      </grid>
+      <grid id="b5e9b" binding="advanced" layout-manager="GridLayoutManager" row-count="17" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="3" column="3" row-span="1" col-span="11" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
-            <preferred-size width="150" height="-1"/>
-          </grid>
+          <tabbedpane title="Advanced"/>
         </constraints>
         <properties>
-          <text value=""/>
-          <toolTipText value="Example: http://myjfrog.acme.org/xray"/>
+          <minimumSize width="0" height="0"/>
+          <preferredSize width="133" height="384"/>
         </properties>
-      </component>
-      <component id="57af0" class="javax.swing.JLabel">
-        <constraints>
-          <grid row="4" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
-            <preferred-size width="133" height="16"/>
-          </grid>
-        </constraints>
-        <properties>
-          <text value="Username"/>
-        </properties>
-      </component>
-      <component id="9bd3b" class="javax.swing.JLabel">
-        <constraints>
-          <grid row="5" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
-            <preferred-size width="133" height="16"/>
-          </grid>
-        </constraints>
-        <properties>
-          <text value="Password"/>
-        </properties>
-      </component>
-      <component id="bf090" class="com.intellij.ui.components.JBTextField" binding="username">
-        <constraints>
-          <grid row="4" column="3" row-span="1" col-span="11" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
-            <preferred-size width="150" height="-1"/>
-          </grid>
-        </constraints>
-        <properties/>
-      </component>
-      <component id="6f33d" class="com.intellij.ui.components.JBPasswordField" binding="password">
-        <constraints>
-          <grid row="5" column="3" row-span="1" col-span="11" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
-            <preferred-size width="150" height="-1"/>
-          </grid>
-        </constraints>
-        <properties/>
-      </component>
-      <component id="5cb50" class="javax.swing.JSeparator">
-        <constraints>
-          <grid row="12" column="0" row-span="1" col-span="14" vsize-policy="0" hsize-policy="6" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties/>
-      </component>
-      <component id="5ec90" class="com.intellij.ui.components.JBCheckBox" binding="connectionDetailsFromEnv">
-        <constraints>
-          <grid row="0" column="0" row-span="1" col-span="14" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <text value="Load connection details from environment variables"/>
-        </properties>
-      </component>
-      <component id="ea8fa" class="javax.swing.JLabel">
-        <constraints>
-          <grid row="1" column="0" row-span="1" col-span="14" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="3" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <enabled value="false"/>
-          <foreground color="-4473925"/>
-          <text value="Load connection details from the JFROG_IDE_URL, JFROG_IDE_USERNAME and"/>
-        </properties>
-      </component>
-      <component id="94e41" class="javax.swing.JLabel">
-        <constraints>
-          <grid row="2" column="0" row-span="1" col-span="14" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="3" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <enabled value="false"/>
-          <text value="JFROG_IDE_PASSWORD environment variables."/>
-        </properties>
-      </component>
-      <component id="9c3e0" class="javax.swing.JLabel">
-        <constraints>
-          <grid row="10" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <text value="Connection retries"/>
-          <toolTipText value=""/>
-        </properties>
-      </component>
-      <component id="1e8d4" class="com.jfrog.ide.idea.ui.configuration.ConnectionRetriesSpinner" binding="connectionRetries">
-        <constraints>
-          <grid row="10" column="3" row-span="1" col-span="11" vsize-policy="0" hsize-policy="1" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties/>
-      </component>
-      <component id="1921d" class="javax.swing.JLabel">
-        <constraints>
-          <grid row="11" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <text value="Connection timeout"/>
-          <toolTipText value="Time in seconds"/>
-        </properties>
-      </component>
-      <component id="d0b8f" class="com.jfrog.ide.idea.ui.configuration.ConnectionTimeoutSpinner" binding="connectionTimeout">
-        <constraints>
-          <grid row="11" column="3" row-span="1" col-span="11" vsize-policy="0" hsize-policy="1" anchor="8" fill="0" indent="0" use-parent-layout="false">
-            <preferred-size width="66" height="30"/>
-          </grid>
-        </constraints>
-        <properties>
-          <editor value=""/>
-          <name value=""/>
-          <toolTipText value="Time in seconds"/>
-        </properties>
-      </component>
-      <component id="678b7" class="javax.swing.JButton" binding="testConnectionButton" default-binding="true">
-        <constraints>
-          <grid row="9" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false">
-            <preferred-size width="133" height="30"/>
-          </grid>
-        </constraints>
-        <properties>
-          <text value="Test connection"/>
-        </properties>
-      </component>
-      <component id="8234b" class="javax.swing.JLabel" binding="connectionResults">
-        <constraints>
-          <grid row="9" column="3" row-span="1" col-span="9" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <enabled value="true"/>
-          <font name="Courier 10 Pitch"/>
-          <text value=""/>
-        </properties>
-      </component>
-      <component id="5641b" class="javax.swing.JLabel">
-        <constraints>
-          <grid row="7" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
-            <preferred-size width="133" height="16"/>
-          </grid>
-        </constraints>
-        <properties>
-          <text value="JFrog Xray URL"/>
-          <toolTipText value=""/>
-        </properties>
-      </component>
-      <component id="c1dce" class="javax.swing.JCheckBox" binding="setRtAndXraySeparately" default-binding="true">
-        <constraints>
-          <grid row="6" column="3" row-span="1" col-span="9" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <text value="Set Artifactory and Xray URLs separately"/>
-        </properties>
-      </component>
-      <component id="a5dab" class="com.intellij.ui.components.JBTextField" binding="xrayUrl">
-        <constraints>
-          <grid row="7" column="3" row-span="1" col-span="11" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
-            <preferred-size width="150" height="-1"/>
-          </grid>
-        </constraints>
-        <properties>
-          <text value=""/>
-          <toolTipText value="Example: http://myjfrog.acme.org/xray"/>
-        </properties>
-      </component>
-      <component id="15430" class="javax.swing.JLabel">
-        <constraints>
-          <grid row="8" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
-            <preferred-size width="133" height="16"/>
-          </grid>
-        </constraints>
-        <properties>
-          <text value="JFrog Artifactory URL"/>
-          <toolTipText value=""/>
-        </properties>
-      </component>
-      <component id="5e6a8" class="com.intellij.ui.components.JBTextField" binding="artifactoryUrl">
-        <constraints>
-          <grid row="8" column="3" row-span="1" col-span="11" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
-            <preferred-size width="150" height="-1"/>
-          </grid>
-        </constraints>
-        <properties>
-          <text value=""/>
-          <toolTipText value="Example: http://myjfrog.acme.org/xray"/>
-        </properties>
-      </component>
-      <component id="dee21" class="javax.swing.JLabel" binding="xrayConnectionResults">
-        <constraints>
-          <grid row="7" column="14" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <text value=""/>
-        </properties>
-      </component>
-      <component id="816ef" class="javax.swing.JLabel" binding="artifactoryConnectionResults">
-        <constraints>
-          <grid row="8" column="14" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <text value=""/>
-        </properties>
-      </component>
-      <component id="97f1c" class="javax.swing.JLabel">
-        <constraints>
-          <grid row="14" column="3" row-span="1" col-span="11" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <enabled value="false"/>
-          <text value="A glob pattern used to exclude specific local paths from being scanned by JFrog Xray."/>
-        </properties>
-      </component>
-      <component id="e7f46" class="javax.swing.JLabel">
-        <constraints>
-          <grid row="16" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <enabled value="false"/>
-          <text value="This is supported only by Gradle, npm and Go projects."/>
-        </properties>
-      </component>
-      <component id="8cbf2" class="javax.swing.JLabel">
-        <constraints>
-          <grid row="17" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <text value="Project"/>
-        </properties>
-      </component>
-      <component id="10519" class="javax.swing.JLabel">
-        <constraints>
-          <grid row="15" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <enabled value="false"/>
-          <text value="For example, package.json files under directories named testdata will not be scanned."/>
-        </properties>
-      </component>
-      <component id="13f88" class="com.intellij.ui.components.JBTextField" binding="excludedPaths">
-        <constraints>
-          <grid row="13" column="3" row-span="1" col-span="11" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
-            <preferred-size width="150" height="-1"/>
-          </grid>
-        </constraints>
-        <properties>
-          <text value="&quot;**/*{.idea,test,node_modules}*&quot;"/>
-          <toolTipText value="Pattern of project paths to exclude from Xray scanning for npm and Go projects."/>
-        </properties>
-      </component>
-      <component id="41a21" class="javax.swing.JLabel">
-        <constraints>
-          <grid row="18" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <enabled value="false"/>
-          <text value="An optional project key in Artifactory. Used as a context for the Xray scanning and for the CI builds."/>
-        </properties>
-      </component>
-      <component id="8c6e3" class="javax.swing.JLabel">
-        <constraints>
-          <grid row="19" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <enabled value="false"/>
-          <text value=""/>
-        </properties>
-      </component>
-      <component id="1c8d6" class="javax.swing.JLabel">
-        <constraints>
-          <grid row="13" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <text value="Excluded paths"/>
-          <toolTipText value="Pattern of project paths to exclude from Xray scanning for npm and Go projects."/>
-        </properties>
-      </component>
-      <component id="481e8" class="com.intellij.ui.components.JBTextField" binding="project">
-        <constraints>
-          <grid row="17" column="3" row-span="1" col-span="11" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
-            <preferred-size width="150" height="-1"/>
-          </grid>
-        </constraints>
-        <properties>
-          <text value=""/>
-          <toolTipText value="Name of Artifactory project. Used for context to Xray scanning."/>
-        </properties>
-      </component>
+        <border type="none"/>
+        <children>
+          <component id="4bae3" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                <preferred-size width="109" height="16"/>
+              </grid>
+            </constraints>
+            <properties>
+              <text value="    Excluded paths"/>
+              <toolTipText value="Pattern of project paths to exclude from Xray scanning for npm and Go projects."/>
+            </properties>
+          </component>
+          <component id="a1d59" class="com.intellij.ui.components.JBTextField" binding="excludedPaths">
+            <constraints>
+              <grid row="5" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="0" fill="1" indent="0" use-parent-layout="false">
+                <preferred-size width="133" height="30"/>
+              </grid>
+            </constraints>
+            <properties>
+              <text value="&quot;**/*{.idea,test,node_modules}*&quot;"/>
+              <toolTipText value="Pattern of project paths to exclude from Xray scanning for npm and Go projects."/>
+            </properties>
+          </component>
+          <component id="72110" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="6" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                <preferred-size width="133" height="16"/>
+              </grid>
+            </constraints>
+            <properties>
+              <enabled value="false"/>
+              <text value="    A glob pattern used to exclude specific local paths from being scanned by JFrog Xray."/>
+            </properties>
+          </component>
+          <component id="11a3e" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="7" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                <preferred-size width="133" height="16"/>
+              </grid>
+            </constraints>
+            <properties>
+              <enabled value="false"/>
+              <text value="    For example, package.json files under directories named testdata will not be scanned."/>
+            </properties>
+          </component>
+          <component id="5b666" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="8" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                <preferred-size width="133" height="16"/>
+              </grid>
+            </constraints>
+            <properties>
+              <enabled value="false"/>
+              <text value="    This is supported only by Gradle, npm and Go projects."/>
+            </properties>
+          </component>
+          <component id="c23ec" class="com.intellij.ui.components.JBTextField" binding="project">
+            <constraints>
+              <grid row="10" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="0" fill="1" indent="0" use-parent-layout="false">
+                <preferred-size width="133" height="30"/>
+              </grid>
+            </constraints>
+            <properties>
+              <text value=""/>
+              <toolTipText value="Name of Artifactory project. Used for context to Xray scanning."/>
+            </properties>
+          </component>
+          <component id="a7d1e" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="11" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                <preferred-size width="133" height="16"/>
+              </grid>
+            </constraints>
+            <properties>
+              <enabled value="false"/>
+              <text value="    Optionally use the Project field to allow the security and license compliance information displayed in"/>
+            </properties>
+          </component>
+          <component id="ed918" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="12" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                <preferred-size width="133" height="16"/>
+              </grid>
+            </constraints>
+            <properties>
+              <enabled value="false"/>
+              <text value="    IntelliJ IDEA, to reflect the Security Policies required by your organization. This is done as follows:"/>
+            </properties>
+          </component>
+          <component id="f96a4" class="com.intellij.ui.HyperlinkLabel" binding="projectInstructions">
+            <constraints>
+              <grid row="13" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                <preferred-size width="133" height="16"/>
+              </grid>
+            </constraints>
+            <properties>
+              <enabled value="true"/>
+              <text value=""/>
+            </properties>
+          </component>
+          <component id="56a19" class="com.intellij.ui.HyperlinkLabel" binding="policyInstructions">
+            <constraints>
+              <grid row="14" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                <preferred-size width="133" height="16"/>
+              </grid>
+            </constraints>
+            <properties>
+              <enabled value="true"/>
+              <text value=""/>
+            </properties>
+          </component>
+          <component id="91349" class="com.intellij.ui.HyperlinkLabel" binding="watchInstructions">
+            <constraints>
+              <grid row="15" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                <preferred-size width="133" height="16"/>
+              </grid>
+            </constraints>
+            <properties>
+              <enabled value="true"/>
+              <text value=""/>
+            </properties>
+          </component>
+          <hspacer id="4cdb6">
+            <constraints>
+              <grid row="5" column="3" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+          </hspacer>
+          <component id="bba68" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="10" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="    Project name"/>
+            </properties>
+          </component>
+          <component id="b50f7" class="com.intellij.ui.TitledSeparator">
+            <constraints>
+              <grid row="4" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Scan Options"/>
+            </properties>
+          </component>
+          <component id="ae0b8" class="com.intellij.ui.TitledSeparator">
+            <constraints>
+              <grid row="9" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="JFrog Project"/>
+            </properties>
+          </component>
+          <component id="52b21" class="com.intellij.ui.TitledSeparator">
+            <constraints>
+              <grid row="1" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Connection Options"/>
+            </properties>
+          </component>
+          <component id="50914" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                <preferred-size width="109" height="16"/>
+              </grid>
+            </constraints>
+            <properties>
+              <text value="    Connection retries"/>
+              <toolTipText value=""/>
+            </properties>
+          </component>
+          <component id="4e0ed" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                <preferred-size width="109" height="16"/>
+              </grid>
+            </constraints>
+            <properties>
+              <text value="    Connection timeout"/>
+              <toolTipText value="Time in seconds"/>
+            </properties>
+          </component>
+          <component id="11827" class="com.jfrog.ide.idea.ui.configuration.ConnectionRetriesSpinner" binding="connectionRetries">
+            <constraints>
+              <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                <preferred-size width="0" height="0"/>
+              </grid>
+            </constraints>
+            <properties/>
+          </component>
+          <component id="17168" class="com.jfrog.ide.idea.ui.configuration.ConnectionTimeoutSpinner" binding="connectionTimeout">
+            <constraints>
+              <grid row="3" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="1" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                <preferred-size width="0" height="0"/>
+              </grid>
+            </constraints>
+            <properties>
+              <editor value=""/>
+              <name value=""/>
+              <toolTipText value="Time in seconds"/>
+            </properties>
+          </component>
+          <hspacer id="3db93">
+            <constraints>
+              <grid row="2" column="2" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+          </hspacer>
+          <hspacer id="580e8">
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="2" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+          </hspacer>
+          <vspacer id="1a765">
+            <constraints>
+              <grid row="16" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
+                <preferred-size width="109" height="14"/>
+              </grid>
+            </constraints>
+          </vspacer>
+        </children>
+      </grid>
     </children>
-  </grid>
+  </tabbedpane>
 </form>


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----

* Split to tabs
* Add explanation for projects

Connection Details tab:
![image](https://user-images.githubusercontent.com/11367982/139591658-7ab30ef4-92da-41b6-83c1-948b0f5b5b4b.png)

Advanced tab:
<img width="1126" alt="image" src="https://user-images.githubusercontent.com/11367982/139593094-513ef505-e3b8-4622-9480-490113cfe28b.png">
