### PR TITLE
Get connection details from JFrog CLI 

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,1 @@
 rootProject.name = 'idea'
-includeBuild "../ide-plugins-common"
-includeBuild "../xray-client-java"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,3 @@
 rootProject.name = 'idea'
+includeBuild "../ide-plugins-common"
+includeBuild "../xray-client-java"

--- a/src/main/java/com/jfrog/ide/idea/configuration/GlobalSettings.java
+++ b/src/main/java/com/jfrog/ide/idea/configuration/GlobalSettings.java
@@ -213,7 +213,7 @@ public final class GlobalSettings implements PersistentStateComponent<GlobalSett
     }
 
     /**
-     * Determine whether should perform credentials migration or not.
+     * Determine whether we should perform credentials migration or not.
      *
      * @param xrayConfig - configurations read from 'jfrogConfig.xml'.
      * @return true if credentials are stored in file.
@@ -222,6 +222,11 @@ public final class GlobalSettings implements PersistentStateComponent<GlobalSett
         return !isAnyBlank(xrayConfig.getUsername(), xrayConfig.getPassword());
     }
 
+    /**
+     * The plugin supports reading the JFrog connection details from JFrog CLI's configuration.
+     * This allows developers who already have JFrog CLI installed and configured,
+     * to have IDEA load the config automatically.
+     */
     public void loadConnectionDetailsFromJfrogCli() {
         // Try to read connection details using JFrog CLI only if no server is already configured.
         if (areXrayCredentialsSet()) {

--- a/src/main/java/com/jfrog/ide/idea/configuration/GlobalSettings.java
+++ b/src/main/java/com/jfrog/ide/idea/configuration/GlobalSettings.java
@@ -25,7 +25,11 @@ import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
 import com.intellij.util.xmlb.XmlSerializerUtil;
+import com.jfrog.ide.idea.log.Logger;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
 
 import static com.jfrog.ide.idea.ui.configuration.Utils.migrateXrayConfigToPlatformConfig;
 import static org.apache.commons.lang3.StringUtils.isAnyBlank;
@@ -216,5 +220,17 @@ public final class GlobalSettings implements PersistentStateComponent<GlobalSett
      */
     private boolean shouldPerformCredentialsMigration(ServerConfigImpl xrayConfig) {
         return !isAnyBlank(xrayConfig.getUsername(), xrayConfig.getPassword());
+    }
+
+    public void loadConnectionDetailsFromJfrogCli() {
+        // Try to read connection details using JFrog CLI only if no server is already configured.
+        if (areXrayCredentialsSet()) {
+            return;
+        }
+        try {
+            serverConfig.readConnectionDetailsFromJfrogCli();
+        } catch (IOException exception) {
+            Logger.getInstance().debug("Couldn't config connection details from JFrog CLI: " + ExceptionUtils.getRootCauseMessage(exception));
+        }
     }
 }

--- a/src/main/java/com/jfrog/ide/idea/configuration/ServerConfigImpl.java
+++ b/src/main/java/com/jfrog/ide/idea/configuration/ServerConfigImpl.java
@@ -27,6 +27,8 @@ import com.intellij.util.net.ssl.CertificateManager;
 import com.intellij.util.xmlb.annotations.OptionTag;
 import com.intellij.util.xmlb.annotations.Tag;
 import com.intellij.util.xmlb.annotations.Transient;
+import com.jfrog.ide.common.configuration.JfrogCliDriver;
+import com.jfrog.ide.common.configuration.JfrogCliServerConfig;
 import com.jfrog.ide.common.configuration.ServerConfig;
 import com.jfrog.ide.idea.ui.configuration.ConnectionRetriesSpinner;
 import com.jfrog.ide.idea.ui.configuration.ConnectionTimeoutSpinner;
@@ -37,6 +39,7 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.net.ssl.SSLContext;
+import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.PasswordAuthentication;
 import java.net.Proxy;
@@ -62,6 +65,7 @@ public class ServerConfigImpl implements ServerConfig {
     static final String USERNAME_ENV = "JFROG_IDE_USERNAME";
     static final String PASSWORD_ENV = "JFROG_IDE_PASSWORD";
     static final String PROJECT_ENV = "JFROG_IDE_PROJECT";
+
 
     @Deprecated
     public static final String XRAY_SETTINGS_KEY = "com.jfrog.xray.idea";
@@ -414,6 +418,36 @@ public class ServerConfigImpl implements ServerConfig {
         }
         setUsername(usernameEnv);
         setPassword(passwordEnv);
+        return true;
+    }
+
+    /**
+     * Read connection details using installed JFrog CLI.
+     * If no JFrog CLI server configuration was found or the config
+     * file is encrypt do nothing.
+     *
+     * @return true if connection details loaded from JFrog CLI default server.
+     */
+    public boolean readConnectionDetailsFromJfrogCli() throws IOException {
+        JfrogCliDriver driver = new JfrogCliDriver(EnvironmentUtil.getEnvironmentMap());
+        if (!driver.isJfrogCliInstalled()) {
+            return false;
+        }
+        JfrogCliServerConfig cliServerConfig = driver.getServerConfig();
+        String platformUrlCLi = cliServerConfig.getUrl();
+        String xrayUrlCli = cliServerConfig.getXrayUrl();
+        String artifactoryUrlCli = cliServerConfig.getArtifactoryUrl();
+        String usernameCli = cliServerConfig.getUsername();
+        String passwordCli = cliServerConfig.getPassword();
+
+        if (isAnyBlank(usernameCli, passwordCli) || isAllBlank(platformUrlCLi, xrayUrlCli, artifactoryUrlCli)) {
+            return false;
+        }
+        setUrl(platformUrlCLi);
+        setXrayUrl(xrayUrlCli);
+        setArtifactoryUrl(artifactoryUrlCli);
+        setUsername(usernameCli);
+        setPassword(passwordCli);
         return true;
     }
 

--- a/src/main/java/com/jfrog/ide/idea/configuration/ServerConfigImpl.java
+++ b/src/main/java/com/jfrog/ide/idea/configuration/ServerConfigImpl.java
@@ -66,7 +66,6 @@ public class ServerConfigImpl implements ServerConfig {
     static final String PASSWORD_ENV = "JFROG_IDE_PASSWORD";
     static final String PROJECT_ENV = "JFROG_IDE_PROJECT";
 
-
     @Deprecated
     public static final String XRAY_SETTINGS_KEY = "com.jfrog.xray.idea";
     @Deprecated
@@ -177,6 +176,11 @@ public class ServerConfigImpl implements ServerConfig {
     @CheckForNull
     public String getPassword() {
         return password;
+    }
+
+    @Override
+    public String getAccessToken() {
+        return null;
     }
 
     public Credentials getCredentialsFromPasswordSafe() {
@@ -422,9 +426,9 @@ public class ServerConfigImpl implements ServerConfig {
     }
 
     /**
-     * Read connection details using installed JFrog CLI.
+     * Read the connection details from JFrog CLI's config. The configuration is read by executing JFrog CLI.
      * If no JFrog CLI server configuration was found or the config
-     * file is encrypt do nothing.
+     * file is encrypt, do nothing.
      *
      * @return true if connection details loaded from JFrog CLI default server.
      */

--- a/src/main/java/com/jfrog/ide/idea/scan/ScanManager.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ScanManager.java
@@ -150,10 +150,6 @@ public abstract class ScanManager extends ScanManagerBase implements Disposable 
                 if (project.isDisposed()) {
                     return;
                 }
-                if (!GlobalSettings.getInstance().areXrayCredentialsSet()) {
-                    getLog().warn("Xray server is not configured.");
-                    return;
-                }
                 // Prevent multiple simultaneous scans
                 if (!scanInProgress.compareAndSet(false, true)) {
                     if (!quickScan) {
@@ -206,7 +202,7 @@ public abstract class ScanManager extends ScanManagerBase implements Disposable 
 
     /**
      * Returns all project modules locations as Paths.
-     * Other scanners such as npm will use this paths in order to find modules.
+     * Other scanners such as npm will use these paths in order to find modules.
      *
      * @return all project modules locations as Paths
      */
@@ -286,7 +282,7 @@ public abstract class ScanManager extends ScanManagerBase implements Disposable 
     protected void checkCanceled() {
         if (project.isOpen()) {
             // The project is closed if we are in test mode.
-            // In tests we can't check if the user canceled the scan, since we don't have the ProgressManager service.
+            // In tests, we can't check if the user canceled the scan, since we don't have the ProgressManager service.
             ProgressManager.checkCanceled();
         }
     }

--- a/src/main/java/com/jfrog/ide/idea/scan/ScanManagersFactory.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ScanManagersFactory.java
@@ -84,6 +84,8 @@ public class ScanManagersFactory implements Disposable {
             Logger.getInstance().info("Previous scan still running...");
             return;
         }
+        // Try to load JFrog CLI config, only if the user hasn't config a server yet.
+        GlobalSettings.getInstance().loadConnectionDetailsFromJfrogCli();
         if (!GlobalSettings.getInstance().areXrayCredentialsSet()) {
             Logger.getInstance().warn("Xray server is not configured.");
             return;


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
Add the ability to retrieve connection details from JFrog CLI config (if exists) by using JFrog CLI.