### PR TITLE
Resolve deadlock in Maven scanning

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/scan/ScanManager.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ScanManager.java
@@ -63,7 +63,7 @@ import static com.jfrog.ide.common.log.Utils.logError;
 public abstract class ScanManager extends ScanManagerBase implements Disposable {
 
     private final MessageBusConnection busConnection;
-    private final ExecutorService executor;
+    private ExecutorService executor;
     protected Project project;
     String basePath;
 
@@ -83,6 +83,10 @@ public abstract class ScanManager extends ScanManagerBase implements Disposable 
         this.executor = executor;
         this.basePath = basePath;
         this.project = project;
+    }
+
+    void setExecutor(ExecutorService executor) {
+        this.executor = executor;
     }
 
     /**

--- a/src/main/java/com/jfrog/ide/idea/scan/ScanManagersFactory.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ScanManagersFactory.java
@@ -130,6 +130,8 @@ public class ScanManagersFactory implements Disposable {
         int projectHash = Utils.getProjectIdentifier(project);
         ScanManager scanManager = this.scanManagers.get(projectHash);
         if (scanManager != null) {
+            // Set the new executor on the old scan manager
+            scanManager.setExecutor(executor);
             scanManagers.put(projectHash, scanManager);
         } else {
             // Unlike other scan managers whereby we create them if the package descriptor exist, the Maven


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----

In hard refresh, the Maven scan manager uses a terminated ExecutorService. This behavior leads to running the refresh on the same thread that waits for it to finish.