### PR TITLE
Show severity icons near dependencies

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/inspections/AbstractInspection.java
+++ b/src/main/java/com/jfrog/ide/idea/inspections/AbstractInspection.java
@@ -118,7 +118,7 @@ public abstract class AbstractInspection extends LocalInspectionTool implements 
     abstract Set<DependencyTree> getModules(PsiElement element, String componentName);
 
     /**
-     * Override this method to avoid displaying multiple annotation icons in the same line.
+     * Override this method to determine whether to display multiple annotation icons in the same line.
      *
      * @param element - The Psi element in the package descriptor
      * @return true if should show annotation icon.

--- a/src/main/java/com/jfrog/ide/idea/inspections/AbstractInspection.java
+++ b/src/main/java/com/jfrog/ide/idea/inspections/AbstractInspection.java
@@ -67,7 +67,7 @@ public abstract class AbstractInspection extends LocalInspectionTool implements 
     void visitElement(AnnotationHolder annotationHolder, PsiElement element) {
         List<DependencyTree> dependencies = getDependencies(element);
         if (CollectionUtils.isNotEmpty(dependencies)) {
-            AnnotationUtils.registerAnnotation(annotationHolder, dependencies.get(0), getTargetElements(element));
+            AnnotationUtils.registerAnnotation(annotationHolder, dependencies.get(0), getTargetElements(element), showAnnotationIcon(element));
         }
     }
 
@@ -116,6 +116,16 @@ public abstract class AbstractInspection extends LocalInspectionTool implements 
      * @return Set of modules containing the dependency or null if not found
      */
     abstract Set<DependencyTree> getModules(PsiElement element, String componentName);
+
+    /**
+     * Override this method to avoid displaying multiple annotation icons in the same line.
+     *
+     * @param element - The Psi element in the package descriptor
+     * @return true if should show annotation icon.
+     */
+    boolean showAnnotationIcon(PsiElement element) {
+        return true;
+    }
 
     /**
      * Determine whether to apply the inspection on the Psi element.

--- a/src/main/java/com/jfrog/ide/idea/inspections/AnnotationIconRenderer.java
+++ b/src/main/java/com/jfrog/ide/idea/inspections/AnnotationIconRenderer.java
@@ -1,0 +1,75 @@
+package com.jfrog.ide.idea.inspections;
+
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.editor.markup.GutterIconRenderer;
+import com.intellij.openapi.project.Project;
+import com.intellij.util.ui.tree.TreeUtil;
+import com.jfrog.ide.idea.ui.LocalComponentsTree;
+import com.jfrog.ide.idea.ui.utils.IconUtils;
+import com.jfrog.ide.idea.utils.Utils;
+import org.apache.commons.lang.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jfrog.build.extractor.scan.DependencyTree;
+import org.jfrog.build.extractor.scan.Severity;
+
+import javax.swing.*;
+import java.util.Objects;
+
+/**
+ * Represents the icon near the dependencies in the package descriptor file.
+ *
+ * @author yahavi
+ **/
+public class AnnotationIconRenderer extends GutterIconRenderer {
+    private final DependencyTree node;
+    private final String tooltipText;
+    private final Icon icon;
+    private Project project;
+
+    public AnnotationIconRenderer(DependencyTree node, String tooltipText) {
+        this.node = node;
+        this.tooltipText = tooltipText;
+        Severity topSeverity = node.getTopIssue().getSeverity();
+        this.icon = IconUtils.load(StringUtils.lowerCase(topSeverity.toString()));
+    }
+
+    public void setProject(Project project) {
+        this.project = project;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof AnnotationIconRenderer)) {
+            return false;
+        }
+        return Objects.equals(icon, ((AnnotationIconRenderer) obj).getIcon());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(icon);
+    }
+
+    @Override
+    public @NotNull Icon getIcon() {
+        return icon;
+    }
+
+    @Override
+    public @Nullable String getTooltipText() {
+        return tooltipText;
+    }
+
+    @Override
+    public @Nullable AnAction getClickAction() {
+        return new AnAction() {
+            @Override
+            public void actionPerformed(@NotNull AnActionEvent e) {
+                Utils.focusJFrogToolWindow(project);
+                TreeUtil.selectInTree(project, node, true, LocalComponentsTree.getInstance(project), true);
+            }
+        };
+    }
+}

--- a/src/main/java/com/jfrog/ide/idea/inspections/GradleInspection.java
+++ b/src/main/java/com/jfrog/ide/idea/inspections/GradleInspection.java
@@ -1,5 +1,6 @@
 package com.jfrog.ide.idea.inspections;
 
+import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.externalSystem.settings.ExternalProjectSettings;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiElement;
@@ -19,6 +20,7 @@ import java.util.stream.Collectors;
  * @author yahavi
  */
 public abstract class GradleInspection extends AbstractInspection {
+    private int lastAnnotatedLine;
 
     public GradleInspection(String packageDescriptorName) {
         super(packageDescriptorName);
@@ -43,6 +45,18 @@ public abstract class GradleInspection extends AbstractInspection {
 
         // Collect the modules containing the dependency
         return collectModules(root, project, gradleModules, componentName);
+    }
+
+    @Override
+    boolean showAnnotationIcon(PsiElement element) {
+        Document document = element.getContainingFile().getViewProvider().getDocument();
+        boolean showAnnotationIcon = true;
+        if (document != null) {
+            int currentLine = document.getLineNumber(element.getTextOffset());
+            showAnnotationIcon = currentLine != lastAnnotatedLine;
+            lastAnnotatedLine = currentLine;
+        }
+        return showAnnotationIcon;
     }
 
     /**


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----

* Instead of showing red or white underlines beneath vulnerable dependencies, show the severity icon near them.
<img width="310" alt="image" src="https://user-images.githubusercontent.com/11367982/146961983-f9be7e06-02c6-430c-a9d7-53f07f770eb3.png">

* Get rid of the meaningless records in the problems views:
<img width="541" alt="image" src="https://user-images.githubusercontent.com/11367982/146962463-430b9318-773a-41a4-bb4d-8d85997e2077.png">
