### PR TITLE
Disable ShowInDependencyTree in batch mode inspection

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/inspections/AbstractInspection.java
+++ b/src/main/java/com/jfrog/ide/idea/inspections/AbstractInspection.java
@@ -45,8 +45,8 @@ public abstract class AbstractInspection extends LocalInspectionTool implements 
      *
      * @param problemsHolder - The "Show in dependency tree" option will be registered in this container.
      * @param element        - The Psi element in the package descriptor
-     * @param isOnTheFly     - True if the inspection triggered by opening a package descriptor file.
-     *                       False if the inspection triggered manually by clicking on "Code | Inspect Code".
+     * @param isOnTheFly     - True if the inspection was triggered by opening a package descriptor file.
+     *                       False if the inspection was triggered manually by clicking on "Code | Inspect Code".
      */
     void visitElement(ProblemsHolder problemsHolder, PsiElement element, boolean isOnTheFly) {
         if (!isOnTheFly) {

--- a/src/main/java/com/jfrog/ide/idea/inspections/AbstractInspection.java
+++ b/src/main/java/com/jfrog/ide/idea/inspections/AbstractInspection.java
@@ -45,8 +45,13 @@ public abstract class AbstractInspection extends LocalInspectionTool implements 
      *
      * @param problemsHolder - The "Show in dependency tree" option will be registered in this container.
      * @param element        - The Psi element in the package descriptor
+     * @param isOnTheFly     - True if the inspection triggered by opening a package descriptor file.
+     *                       False if the inspection triggered manually by clicking on "Code | Inspect Code".
      */
-    void visitElement(ProblemsHolder problemsHolder, PsiElement element) {
+    void visitElement(ProblemsHolder problemsHolder, PsiElement element, boolean isOnTheFly) {
+        if (!isOnTheFly) {
+            return;
+        }
         List<DependencyTree> dependencies = getDependencies(element);
         if (CollectionUtils.isEmpty(dependencies)) {
             return;

--- a/src/main/java/com/jfrog/ide/idea/inspections/GoInspection.java
+++ b/src/main/java/com/jfrog/ide/idea/inspections/GoInspection.java
@@ -34,7 +34,7 @@ public class GoInspection extends AbstractInspection {
             @Override
             public void visitModuleSpec(@NotNull VgoModuleSpec element) {
                 super.visitPsiElement(element);
-                GoInspection.this.visitElement(holder, element);
+                GoInspection.this.visitElement(holder, element, isOnTheFly);
             }
         };
     }

--- a/src/main/java/com/jfrog/ide/idea/inspections/GradleGroovyInspection.java
+++ b/src/main/java/com/jfrog/ide/idea/inspections/GradleGroovyInspection.java
@@ -34,7 +34,7 @@ public class GradleGroovyInspection extends GradleInspection {
         return new GroovyPsiElementVisitor(new GroovyElementVisitor() {
             @Override
             public void visitLiteralExpression(@NotNull GrLiteral literal) {
-                GradleGroovyInspection.this.visitElement(holder, literal);
+                GradleGroovyInspection.this.visitElement(holder, literal, isOnTheFly);
             }
         });
     }

--- a/src/main/java/com/jfrog/ide/idea/inspections/GradleKotlinInspection.java
+++ b/src/main/java/com/jfrog/ide/idea/inspections/GradleKotlinInspection.java
@@ -32,7 +32,7 @@ public class GradleKotlinInspection extends GradleInspection {
         return new KtVisitor<Void, Void>() {
             @Override
             public Void visitValueArgumentList(@NotNull KtValueArgumentList list, Void data) {
-                GradleKotlinInspection.this.visitElement(holder, list);
+                GradleKotlinInspection.this.visitElement(holder, list, isOnTheFly);
                 return null;
             }
         };

--- a/src/main/java/com/jfrog/ide/idea/inspections/MavenInspection.java
+++ b/src/main/java/com/jfrog/ide/idea/inspections/MavenInspection.java
@@ -41,7 +41,7 @@ public class MavenInspection extends AbstractInspection {
             @Override
             public void visitXmlTag(XmlTag element) {
                 super.visitElement(element);
-                MavenInspection.this.visitElement(holder, element);
+                MavenInspection.this.visitElement(holder, element, isOnTheFly);
             }
         };
     }

--- a/src/main/java/com/jfrog/ide/idea/inspections/NpmInspection.java
+++ b/src/main/java/com/jfrog/ide/idea/inspections/NpmInspection.java
@@ -32,7 +32,7 @@ public class NpmInspection extends AbstractInspection {
             @Override
             public void visitProperty(@NotNull JsonProperty element) {
                 super.visitProperty(element);
-                NpmInspection.this.visitElement(holder, element);
+                NpmInspection.this.visitElement(holder, element, isOnTheFly);
             }
         };
     }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----

Registring the `ShowInDependencyTree` problem should not occur when triggering code inspection manually A.K.A. [batch mode inspection](https://www.jetbrains.com/help/idea/running-inspections.html#run-inspections-manually).
This change is needed for 2 reasons:
1. The `ShowInDependencyTree` is not a real problem that should be shown in the code inspection.
2. Since this is an information level problem, an exception is thrown when running in batch mode, since the inspector skips them:
> com.intellij.diagnostic.PluginException: Tool #Npm registers INFORMATION level problem in batch mode on JsonFile: package.json. INFORMATION level 'warnings' are invisible in the editor and should not become visible in batch mode. Moreover, cause INFORMATION level fixes act more like intention actions, they could e.g. change semantics and thus should not be suggested for batch transformations [Plugin: org.jfrog.idea]