### PR TITLE
Remove credentials migration from file to PasswordSafe

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/configuration/GlobalSettings.java
+++ b/src/main/java/com/jfrog/ide/idea/configuration/GlobalSettings.java
@@ -19,7 +19,6 @@
  */
 package com.jfrog.ide.idea.configuration;
 
-import com.intellij.openapi.application.Application;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.State;
@@ -33,7 +32,6 @@ import java.io.IOException;
 
 import static com.jfrog.ide.idea.ui.configuration.Utils.migrateXrayConfigToPlatformConfig;
 import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.apache.commons.lang3.StringUtils.isNoneBlank;
 
 /**
  * @author yahavi
@@ -143,11 +141,7 @@ public final class GlobalSettings implements PersistentStateComponent<GlobalSett
 
         // Load configuration from state.
         setCommonConfigFields(serverConfig);
-        if (shouldPerformCredentialsMigration(serverConfig)) {
-            migrateCredentialsFromFileToPasswordSafe(serverConfig);
-        } else {
-            this.serverConfig.setCredentials(serverConfig.getCredentialsFromPasswordSafe());
-        }
+        this.serverConfig.setCredentials(serverConfig.getCredentialsFromPasswordSafe());
     }
 
     /**
@@ -200,32 +194,6 @@ public final class GlobalSettings implements PersistentStateComponent<GlobalSett
 
     public boolean areArtifactoryCredentialsSet() {
         return serverConfig != null && serverConfig.isArtifactoryConfigured();
-    }
-
-    /**
-     * Perform credentials migration from file to PasswordSafe.
-     * If credentials were stored on file, set the new values from it, save to PasswordSafe
-     * and persist configuration to file.
-     *
-     * @param serverConfig - configurations read from 'jfrogConfig.xml'.
-     */
-    private void migrateCredentialsFromFileToPasswordSafe(ServerConfigImpl serverConfig) {
-        this.serverConfig.setUsername(serverConfig.getUsername());
-        this.serverConfig.setPassword(serverConfig.getPassword());
-        this.serverConfig.setAccessToken(serverConfig.getAccessToken());
-        this.serverConfig.addCredentialsToPasswordSafe();
-        Application application = ApplicationManager.getApplication();
-        application.invokeLater(application::saveSettings);
-    }
-
-    /**
-     * Determine whether we should perform credentials migration or not.
-     *
-     * @param xrayConfig - configurations read from 'jfrogConfig.xml'.
-     * @return true if credentials are stored in file.
-     */
-    private boolean shouldPerformCredentialsMigration(ServerConfigImpl xrayConfig) {
-        return isNoneBlank(xrayConfig.getUsername(), xrayConfig.getPassword());
     }
 
     /**

--- a/src/test/java/com/jfrog/ide/idea/configuration/ConfigurationTest.java
+++ b/src/test/java/com/jfrog/ide/idea/configuration/ConfigurationTest.java
@@ -3,7 +3,6 @@ package com.jfrog.ide.idea.configuration;
 import com.intellij.credentialStore.Credentials;
 import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase;
 import com.intellij.util.EnvironmentUtil;
-import com.jfrog.ide.idea.ui.configuration.Utils;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
@@ -112,35 +111,6 @@ public class ConfigurationTest extends LightJavaCodeInsightFixtureTestCase {
         globalSettings.setServerConfig(serverConfig);
         actualServerConfig = globalSettings.getServerConfig();
         assertEquals(PolicyType.WATCHES, actualServerConfig.getPolicyType());
-    }
-
-    /**
-     * Test set server config in the GlobalSettings with migration from file to PasswordSafe.
-     */
-    public void testSetServerConfigCredentialsMigration() {
-        // Create overriding server config
-        GlobalSettings globalSettings = new GlobalSettings();
-        ServerConfigImpl overrideServerConfig = createServerConfig(true, true);
-        globalSettings.setServerConfig(overrideServerConfig);
-
-        // Check that the server in the global settings was overridden.
-        ServerConfigImpl actualServerConfig = globalSettings.getServerConfig();
-        assertFalse(actualServerConfig.isConnectionDetailsFromEnv());
-        assertEquals(PLATFORM_URL, actualServerConfig.getUrl());
-        assertEquals(XRAY_URL, actualServerConfig.getXrayUrl());
-        assertEquals(ARTIFACTORY_URL, actualServerConfig.getArtifactoryUrl());
-        assertEquals(USERNAME, actualServerConfig.getUsername());
-        assertEquals(PASSWORD, actualServerConfig.getPassword());
-        assertEquals(CONNECTION_RETRIES, actualServerConfig.getConnectionRetries());
-        assertEquals(CONNECTION_TIMEOUT, actualServerConfig.getConnectionTimeout());
-        assertEquals(EXCLUDED_PATHS, actualServerConfig.getExcludedPaths());
-        assertEquals(JFROG_PROJECT, actualServerConfig.getProject());
-
-        // Check credential were migrated to PasswordSafe
-        Credentials credentials = actualServerConfig.getCredentialsFromPasswordSafe();
-        assertNotNull(credentials);
-        assertEquals(USERNAME, credentials.getUserName());
-        assertEquals(PASSWORD, credentials.getPasswordAsString());
     }
 
     /**
@@ -254,8 +224,6 @@ public class ConfigurationTest extends LightJavaCodeInsightFixtureTestCase {
         // Create overriding server config
         GlobalSettings globalSettings = new GlobalSettings();
         XrayServerConfigImpl xrayServerConfig = createLegacyServerConfig();
-        xrayServerConfig.setUsername(USERNAME);
-        xrayServerConfig.setPassword(PASSWORD);
         globalSettings.setXrayConfig(xrayServerConfig);
 
         // Check that the xrayServerConfig was migrated to serverConfig
@@ -264,45 +232,9 @@ public class ConfigurationTest extends LightJavaCodeInsightFixtureTestCase {
         assertEquals(PLATFORM_URL, actualServerConfig.getUrl());
         assertEquals(XRAY_URL, actualServerConfig.getXrayUrl());
         assertEquals(ARTIFACTORY_URL, actualServerConfig.getArtifactoryUrl());
-        assertEquals(USERNAME, actualServerConfig.getUsername());
-        assertEquals(PASSWORD, actualServerConfig.getPassword());
         assertEquals(CONNECTION_RETRIES, actualServerConfig.getConnectionRetries());
         assertEquals(CONNECTION_TIMEOUT, actualServerConfig.getConnectionTimeout());
         assertEquals(EXCLUDED_PATHS, actualServerConfig.getExcludedPaths());
-
-        // Make sure credentials migrated PasswordSafe
-        Credentials credentials = actualServerConfig.getCredentialsFromPasswordSafe();
-        assertEquals(USERNAME, credentials.getUserName());
-        assertEquals(PASSWORD, credentials.getPasswordAsString());
-    }
-
-    @SuppressWarnings("deprecation")
-    public void testMigrateXrayConfigFromPasswordSafe() {
-        // Create overriding server config
-        GlobalSettings globalSettings = new GlobalSettings();
-        XrayServerConfigImpl xrayServerConfig = createLegacyServerConfig();
-        Credentials credentials = new Credentials(USERNAME, PASSWORD);
-        Utils.storeCredentialsInPasswordSafe(XRAY_SETTINGS_CREDENTIALS_KEY, xrayServerConfig.getUrl(), credentials);
-        globalSettings.setXrayConfig(xrayServerConfig);
-
-        // Check that the xrayServerConfig was migrated to serverConfig
-        ServerConfigImpl actualServerConfig = globalSettings.getServerConfig();
-        assertFalse(actualServerConfig.isConnectionDetailsFromEnv());
-        assertEquals(PLATFORM_URL, actualServerConfig.getUrl());
-        assertEquals(XRAY_URL, actualServerConfig.getXrayUrl());
-        assertEquals(ARTIFACTORY_URL, actualServerConfig.getArtifactoryUrl());
-        assertEquals(USERNAME, actualServerConfig.getUsername());
-        assertEquals(PASSWORD, actualServerConfig.getPassword());
-        assertEquals(CONNECTION_RETRIES, actualServerConfig.getConnectionRetries());
-        assertEquals(CONNECTION_TIMEOUT, actualServerConfig.getConnectionTimeout());
-        assertEquals(EXCLUDED_PATHS, actualServerConfig.getExcludedPaths());
-
-        // Make sure credentials migrated in PasswordSafe
-        credentials = Utils.retrieveCredentialsFromPasswordSafe(XRAY_SETTINGS_CREDENTIALS_KEY, xrayServerConfig.getUrl());
-        assertNull(credentials);
-        credentials = actualServerConfig.getCredentialsFromPasswordSafe();
-        assertEquals(USERNAME, credentials.getUserName());
-        assertEquals(PASSWORD, credentials.getPasswordAsString());
     }
 
     /**


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----

Remove all code migrating the credentials from a file to PasswordSafe. (Introduced in https://github.com/jfrog/jfrog-idea-plugin/pull/47)
Clarification - the migration from Xray URL to platform URL was not removed (Introduced in https://github.com/jfrog/jfrog-idea-plugin/pull/103).