### PR TITLE
Fix connection details from env instructions

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/ui/configuration/JFrogGlobalConfiguration.form
+++ b/src/main/java/com/jfrog/ide/idea/ui/configuration/JFrogGlobalConfiguration.form
@@ -197,7 +197,7 @@
             <properties>
               <enabled value="false"/>
               <foreground color="-4473925"/>
-              <text value="Load connection details from the JFROG_IDE_URL, JFROG_IDE_USERNAME,"/>
+              <text value="Load connection details from the JFROG_IDE_PLATFORM_URL, JFROG_IDE_USERNAME,"/>
             </properties>
           </component>
           <component id="23de2" class="com.intellij.ui.components.JBCheckBox" binding="connectionDetailsFromEnv">


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----

The JFROG_IDE_URL is a legacy and should not appear in the UI. This environment variable configures Xray URL and not the platform URL. Instead, JFROG_IDE_PLATFORM_URL should be.

Before:
![image](https://user-images.githubusercontent.com/11367982/154059453-2a4188ed-60f0-4fa5-8664-1c6dd774a6bc.png)

After:
<img width="727" alt="image" src="https://user-images.githubusercontent.com/11367982/154059687-fd4fc620-5dd3-4efe-8282-37affed4d922.png">
