### PR TITLE
Fix generate CSV in multiproject configuration

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/ui/ComponentsTree.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/ComponentsTree.java
@@ -104,6 +104,7 @@ public abstract class ComponentsTree extends Tree {
             DependencyTree newRoot = filteredRoot;
             if (!Utils.areRootNodesEqual(root, filteredRoot)) {
                 newRoot = new DependencyTree();
+                newRoot.setMetadata(true);
                 newRoot.add(root);
                 newRoot.add(filteredRoot);
             }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----

In a multi-project configuration, the root node should mark as metadata. Otherwise, the CSV exported will skip the projects:
https://github.com/jfrog/ide-plugins-common/blob/1.11.0/src/main/java/com/jfrog/ide/common/exporter/Exporter.java#L70