### PR TITLE
Better handling UI events

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ apply plugin: 'idea'
 apply plugin: 'org.jetbrains.intellij'
 apply plugin: 'java'
 
-def sandboxVersion = 'IU-2020.3.1'
+def sandboxVersion = 'IU-2020.3.2'
 intellij {
     version sandboxVersion
     plugins = ['gradle', 'maven', 'Groovy', 'properties', 'java', 'Kotlin', 'org.jetbrains.plugins.go:203.5981.155', 'Pythonid:203.5981.165']

--- a/src/main/java/com/jfrog/ide/idea/ci/CiManager.java
+++ b/src/main/java/com/jfrog/ide/idea/ci/CiManager.java
@@ -81,6 +81,7 @@ public class CiManager extends CiManagerBase implements Disposable {
                     if (project.isDisposed()) {
                         return;
                     }
+                    project.getMessageBus().syncPublisher(ApplicationEvents.ON_SCAN_CI_STARTED).update();
                     String buildsPattern = propertiesComponent.getValue(BUILDS_PATTERN_KEY);
                     buildCiTree(buildsPattern, GlobalSettings.getInstance().getServerConfig().getProject(),
                             new ProgressIndicatorImpl(indicator), () -> checkCanceled(indicator), shouldToast);

--- a/src/main/java/com/jfrog/ide/idea/configuration/GlobalSettings.java
+++ b/src/main/java/com/jfrog/ide/idea/configuration/GlobalSettings.java
@@ -200,17 +200,19 @@ public final class GlobalSettings implements PersistentStateComponent<GlobalSett
      * The plugin supports reading the JFrog connection details from JFrog CLI's configuration.
      * This allows developers who already have JFrog CLI installed and configured,
      * to have IDEA load the config automatically.
+     *
+     * @return true if connection details from CLI were loaded.
      */
-    public void loadConnectionDetailsFromJfrogCli() {
-        // Try to read connection details using JFrog CLI only if no server is already configured.
-        if (areXrayCredentialsSet()) {
-            return;
-        }
+    public boolean loadConnectionDetailsFromJfrogCli() {
         try {
-            String configured = serverConfig.readConnectionDetailsFromJfrogCli() ? "Successfully" : "Couldn't";
-            Logger.getInstance().info(configured + " config connection details from JFrog CLI");
+            if (serverConfig.readConnectionDetailsFromJfrogCli()) {
+                Logger.getInstance().info("Successfully loaded config connection details from JFrog CLI");
+                return true;
+            }
         } catch (IOException exception) {
-            Logger.getInstance().debug("Couldn't config connection details from JFrog CLI: " + ExceptionUtils.getRootCauseMessage(exception));
+            Logger.getInstance().warn(ExceptionUtils.getRootCauseMessage(exception));
         }
+        Logger.getInstance().debug("Couldn't load config connection details from JFrog CLI");
+        return false;
     }
 }

--- a/src/main/java/com/jfrog/ide/idea/events/ApplicationEvents.java
+++ b/src/main/java/com/jfrog/ide/idea/events/ApplicationEvents.java
@@ -8,13 +8,20 @@ import com.intellij.util.messages.Topic;
  * Created by romang on 3/5/17.
  */
 public interface ApplicationEvents {
+    // Scan started
+    Topic<ApplicationEvents> ON_SCAN_LOCAL_STARTED = Topic.create("Local scan started", ApplicationEvents.class);
+    Topic<ApplicationEvents> ON_SCAN_CI_STARTED = Topic.create("CI scan started", ApplicationEvents.class);
+
+    // Configuration changed
     Topic<ApplicationEvents> ON_CONFIGURATION_DETAILS_CHANGE = Topic.create("Configuration details changed", ApplicationEvents.class);
     Topic<ApplicationEvents> ON_BUILDS_CONFIGURATION_CHANGE = Topic.create("Builds configuration changed", ApplicationEvents.class);
+
+    // Filter changed
     Topic<ApplicationEvents> ON_SCAN_FILTER_CHANGE = Topic.create("Scan issues changed", ApplicationEvents.class);
     Topic<ApplicationEvents> ON_CI_FILTER_CHANGE = Topic.create("CI issues changed", ApplicationEvents.class);
 
     /**
-     * Called when the store of issues in changed files is modified. It is modified only as a result of a user action to analyse all changed files.
+     * Called when a scan started, a configuration changed or a filter changed.
      */
     void update();
 

--- a/src/main/java/com/jfrog/ide/idea/ui/AbstractJFrogToolWindow.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/AbstractJFrogToolWindow.java
@@ -29,8 +29,9 @@ import org.jfrog.build.extractor.scan.Issue;
 import javax.swing.*;
 import javax.swing.tree.TreePath;
 import java.awt.*;
+import java.util.Arrays;
 import java.util.List;
-import java.util.*;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.jfrog.ide.idea.ui.JFrogToolWindow.*;
@@ -227,7 +228,7 @@ public abstract class AbstractJFrogToolWindow extends SimpleToolWindowPanel impl
      */
     public void onConfigurationChange() {
         rightVerticalSplit.setSecondComponent(createMoreInfoView(true));
-        issuesTable.updateIssuesTable(new HashSet<>(), new LinkedList<>());
+        resetViews();
         issuesTable.addTableSelectionListener(moreInfoPanel);
     }
 
@@ -253,6 +254,18 @@ public abstract class AbstractJFrogToolWindow extends SimpleToolWindowPanel impl
         issuesTable.addTableSelectionListener(moreInfoPanel);
         componentsTree.addOnProjectChangeListener(projectBusConnection);
         componentsTree.addRightClickListener();
+    }
+
+    /**
+     * Clear the component tree and the issues table.
+     */
+    void resetViews() {
+        if (componentsTree != null) {
+            componentsTree.reset();
+        }
+        if (issuesTable != null) {
+            issuesTable.reset();
+        }
     }
 
     @Override

--- a/src/main/java/com/jfrog/ide/idea/ui/ComponentIssuesTable.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/ComponentIssuesTable.java
@@ -12,9 +12,7 @@ import javax.swing.table.TableModel;
 import javax.swing.table.TableRowSorter;
 import javax.swing.tree.DefaultMutableTreeNode;
 import java.awt.event.MouseListener;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.jfrog.ide.idea.ui.IssuesTableModel.IssueColumn.*;
@@ -36,6 +34,10 @@ public class ComponentIssuesTable extends JBTable {
         setDefaultRenderer(Object.class, new IssuesTableCellRenderer());
         getTableHeader().setReorderingAllowed(false);
         setAutoResizeMode(AUTO_RESIZE_OFF);
+    }
+
+    public void reset() {
+        updateIssuesTable(new HashSet<>(), new ArrayList<>());
     }
 
     public void updateIssuesTable(Set<Issue> selectedIssue, List<DependencyTree> selectedNodes) {

--- a/src/main/java/com/jfrog/ide/idea/ui/JFrogCiToolWindow.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/JFrogCiToolWindow.java
@@ -120,6 +120,7 @@ public class JFrogCiToolWindow extends AbstractJFrogToolWindow {
             CiComponentsTree.getInstance(project).applyFiltersForAllProjects();
             updateIssuesTable();
         }));
+        projectBusConnection.subscribe(ApplicationEvents.ON_SCAN_CI_STARTED, () -> ApplicationManager.getApplication().invokeLater(this::resetViews));
         projectBusConnection.subscribe(BuildEvents.ON_SELECTED_BUILD, this::setBuildDetails);
         projectBusConnection.subscribe(ApplicationEvents.ON_BUILDS_CONFIGURATION_CHANGE, () -> ApplicationManager.getApplication().invokeLater(this::onConfigurationChange));
     }

--- a/src/main/java/com/jfrog/ide/idea/ui/JFrogLocalToolWindow.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/JFrogLocalToolWindow.java
@@ -99,5 +99,6 @@ public class JFrogLocalToolWindow extends AbstractJFrogToolWindow {
             LocalComponentsTree.getInstance(project).applyFiltersForAllProjects();
             updateIssuesTable();
         }));
+        projectBusConnection.subscribe(ApplicationEvents.ON_SCAN_LOCAL_STARTED, () -> ApplicationManager.getApplication().invokeLater(this::resetViews));
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -18,7 +18,7 @@
     </change-notes>
 
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
-    <idea-version since-build="203.5419.21"/>
+    <idea-version since-build="203.7148.57"/>
     <depends>com.intellij.modules.lang</depends>
     <depends config-file="with-java.xml" optional="true">com.intellij.modules.java</depends>
     <depends config-file="with-gradle.xml" optional="true">com.intellij.gradle</depends>


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----

Fix the following UI issues:
* Fix an issue whereby reading credentials from CLI doesn't initiate the "More Info" panel.
* Fix an issue whereby starting a new scan doesn't reset the dependency tree and the issues table.

Update supported version from `IU-2020.3.1` to `IU-2020.3.2`, in order to handle an exception thrown in the latest macOS:
> java.lang.ClassNotFoundException: com.apple.eawt.OpenURIHandler