### PR TITLE
Improve Gradle projects scanning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     implementation group: 'com.jfrog.xray.client', name: 'xray-client-java', version: '0.11.0'
     implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
     implementation group: 'org.jfrog.filespecs', name: 'file-specs-java', version: '1.1.0'
-    implementation group: 'com.jfrog.ide', name: 'ide-plugins-common', version: '1.11.x-20220313.125333-1'
+    implementation group: 'com.jfrog.ide', name: 'ide-plugins-common', version: '1.12.x-20220606.055503-1'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.11'
     implementation group: 'com.google.guava', name: 'guava', version: '30.1.1-jre'
 

--- a/src/main/java/com/jfrog/ide/idea/scan/GradleScanManager.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/GradleScanManager.java
@@ -2,7 +2,9 @@ package com.jfrog.ide.idea.scan;
 
 import com.google.common.collect.Maps;
 import com.intellij.codeInspection.LocalInspectionTool;
+import com.intellij.ide.plugins.PluginManagerCore;
 import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -52,6 +54,8 @@ public class GradleScanManager extends ScanManager {
         super(project, basePath, ComponentPrefix.GAV, executor);
         getLog().info("Found Gradle project: " + getProjectName());
         Map<String, String> env = Maps.newHashMap(EnvironmentUtil.getEnvironmentMap());
+        Path pluginLibDir = PluginManagerCore.getPlugin(PluginId.findId("org.jfrog.idea")).getPluginPath().resolve("lib");
+        env.put("pluginLibDir", pluginLibDir.toAbsolutePath().toString());
         gradleTreeBuilder = new GradleTreeBuilder(Paths.get(basePath), env, getGradleExeAndJdk(env));
     }
 

--- a/src/test/java/com/jfrog/ide/idea/scan/GradleScanManagerTest.java
+++ b/src/test/java/com/jfrog/ide/idea/scan/GradleScanManagerTest.java
@@ -79,7 +79,7 @@ public class GradleScanManagerTest extends HeavyPlatformTestCase {
         assertTrue(results.isMetadata());
         assertEquals(Paths.get(globalProjectDir).getFileName().toString(), results.getUserObject());
         assertScopes(results);
-        assertEquals(5, results.getChildCount());
+        assertEquals(3, results.getChildCount());
 
         // Check module dependency
         DependencyTree moduleNode = getAndAssertChild(results, "shared");
@@ -89,6 +89,6 @@ public class GradleScanManagerTest extends HeavyPlatformTestCase {
         // Check dependency
         DependencyTree dependencyNode = getAndAssertChild(moduleNode, "junit:junit:4.7");
         assertFalse(dependencyNode.isMetadata());
-        assertContainsElements(dependencyNode.getScopes(), new Scope("Compile"), new Scope("Runtime"));
+        assertContainsElements(dependencyNode.getScopes(), new Scope("TestImplementation"), new Scope("TestRuntimeClasspath"), new Scope("TestCompileClasspath"));
     }
 }


### PR DESCRIPTION
- [X] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----

Depends on https://github.com/jfrog/ide-plugins-common/pull/77 & https://github.com/jfrog/gradle-deps-tree/pull/1

New features:
1. Better accuracy - use the same APIs as `gradle dependencies` task does. The dependency tree should contain a more detailed view of Gradle configurations.
2. Performance -
  a. Unlike before, the task runs on each subproject exactly once.
  b. Use task cache. The cache is stored in the `${buildDir}/gradle-deps-tree` and invalidated if there was a change in the Gradle project.
