### PR TITLE
Fix IllegalArgumentException in some scenarios

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/scan/ScanManager.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ScanManager.java
@@ -194,7 +194,14 @@ public abstract class ScanManager extends ScanManagerBase implements Disposable 
      * @return text to display in the task progress.
      */
     private String getTaskTitle() {
-        String relativePath = Utils.getProjectBasePath(project).relativize(Paths.get(basePath)).toString();
+        Path projectBasePath = Utils.getProjectBasePath(project);
+        Path wsBasePath = Paths.get(basePath);
+        String relativePath = "";
+        if (projectBasePath.isAbsolute() != wsBasePath.isAbsolute()) {
+            // If one of the path is relative and the other one is absolute, the following exception is thrown:
+            // IllegalArgumentException: 'other' is different type of Path
+            relativePath = projectBasePath.relativize(wsBasePath).toString();
+        }
         return "Xray scanning " + StringUtils.defaultIfBlank(relativePath, project.getName());
     }
 

--- a/src/main/java/com/jfrog/ide/idea/scan/ScanManager.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ScanManager.java
@@ -202,7 +202,7 @@ public abstract class ScanManager extends ScanManagerBase implements Disposable 
             // IllegalArgumentException: 'other' is different type of Path
             relativePath = projectBasePath.relativize(wsBasePath).toString();
         }
-        return "Xray scanning " + StringUtils.defaultIfBlank(relativePath, project.getName());
+        return "JFrog Xray scanning " + StringUtils.defaultIfBlank(relativePath, project.getName());
     }
 
     /**


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----

Fix the following exception:
> IllegalArgumentException: 'other' is different type of Path
java.lang.IllegalArgumentException: 'other' is different type of Path
    at java.base/sun.nio.fs.WindowsPath.relativize(WindowsPath.java:400)
    at java.base/sun.nio.fs.WindowsPath.relativize(WindowsPath.java:42)
    at com.jfrog.ide.idea.scan.ScanManager.getTaskTitle(ScanManager.java:197)
    at com.jfrog.ide.idea.scan.ScanManager.asyncScanAndUpdateResults(ScanManager.java:157)
    at com.jfrog.ide.idea.scan.ScanManagersFactory.startScan(ScanManagersFactory.java:99)
    at com.jfrog.ide.idea.scan.ScanManagersFactory.lambda$registerOnChangeHandlers$0(ScanManagersFactory.java:69)