### PR TITLE
Avoid popup on fatal errors

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/log/Logger.java
+++ b/src/main/java/com/jfrog/ide/idea/log/Logger.java
@@ -57,7 +57,8 @@ public class Logger implements Log {
      */
     @Override
     public void error(String message) {
-        ideaLogger.error(message);
+        // We log to IntelliJ log in "warn" log level to avoid popup annoying fatal errors
+        ideaLogger.warn(message);
         NotificationType notificationType = NotificationType.ERROR;
         popupBalloon(message, notificationType);
         log(ERROR_TITLE, message, notificationType);
@@ -72,7 +73,8 @@ public class Logger implements Log {
      */
     @Override
     public void error(String message, Throwable t) {
-        ideaLogger.error(message, t);
+        // We log to IntelliJ log in "warn" log level to avoid popup annoying fatal errors
+        ideaLogger.warn(message, t);
         NotificationType notificationType = NotificationType.ERROR;
         popupBalloon(message, notificationType);
         String title = StringUtils.defaultIfBlank(t.getMessage(), ERROR_TITLE);


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----

Avoid popup to the "IDE Fatal Error", such as:
<img width="830" alt="image" src="https://user-images.githubusercontent.com/11367982/171863306-2cb5db17-b947-4817-a7e0-277804b6037b.png">

All errors are still logged in the regular event log of the plugin, with their log level.