### PR TITLE
Bugfix - code inspection does not run after an Xray scan

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/inspections/AbstractInspection.java
+++ b/src/main/java/com/jfrog/ide/idea/inspections/AbstractInspection.java
@@ -34,9 +34,15 @@ import java.util.stream.Collectors;
 public abstract class AbstractInspection extends LocalInspectionTool implements Annotator {
 
     private final String packageDescriptorName;
+    // True if the code inspection was automatically triggered after an Xray scan using InspectionEngine.runInspectionOnFile(...).
+    private boolean afterScan;
 
     AbstractInspection(String packageDescriptorName) {
         this.packageDescriptorName = packageDescriptorName;
+    }
+
+    public void setAfterScan(boolean afterScan) {
+        this.afterScan = afterScan;
     }
 
     /**
@@ -49,7 +55,8 @@ public abstract class AbstractInspection extends LocalInspectionTool implements 
      *                       False if the inspection was triggered manually by clicking on "Code | Inspect Code".
      */
     void visitElement(ProblemsHolder problemsHolder, PsiElement element, boolean isOnTheFly) {
-        if (!isOnTheFly) {
+        if (!afterScan && !isOnTheFly) {
+            // Code inspection was triggered manually by clicking on "Code | Inspect Code".
             return;
         }
         List<DependencyTree> dependencies = getDependencies(element);

--- a/src/main/java/com/jfrog/ide/idea/scan/GoScanManager.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/GoScanManager.java
@@ -1,7 +1,6 @@
 package com.jfrog.ide.idea.scan;
 
 import com.google.common.collect.Maps;
-import com.intellij.codeInspection.LocalInspectionTool;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -10,6 +9,7 @@ import com.intellij.psi.PsiManager;
 import com.intellij.util.EnvironmentUtil;
 import com.jfrog.ide.common.go.GoTreeBuilder;
 import com.jfrog.ide.common.scan.ComponentPrefix;
+import com.jfrog.ide.idea.inspections.AbstractInspection;
 import com.jfrog.ide.idea.inspections.GoInspection;
 import com.jfrog.ide.idea.ui.ComponentsTree;
 import com.jfrog.ide.idea.ui.menus.filtermanager.ConsistentFilterManager;
@@ -65,7 +65,7 @@ public class GoScanManager extends ScanManager {
     }
 
     @Override
-    protected LocalInspectionTool getInspectionTool() {
+    protected AbstractInspection getInspectionTool() {
         return new GoInspection();
     }
 

--- a/src/main/java/com/jfrog/ide/idea/scan/GradleScanManager.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/GradleScanManager.java
@@ -1,7 +1,6 @@
 package com.jfrog.ide.idea.scan;
 
 import com.google.common.collect.Maps;
-import com.intellij.codeInspection.LocalInspectionTool;
 import com.intellij.ide.plugins.PluginManagerCore;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.extensions.PluginId;
@@ -13,6 +12,7 @@ import com.intellij.psi.PsiManager;
 import com.intellij.util.EnvironmentUtil;
 import com.jfrog.ide.common.gradle.GradleTreeBuilder;
 import com.jfrog.ide.common.scan.ComponentPrefix;
+import com.jfrog.ide.idea.inspections.AbstractInspection;
 import com.jfrog.ide.idea.inspections.GradleGroovyInspection;
 import com.jfrog.ide.idea.inspections.GradleKotlinInspection;
 import com.jfrog.ide.idea.log.Logger;
@@ -76,7 +76,7 @@ public class GradleScanManager extends ScanManager {
     }
 
     @Override
-    protected LocalInspectionTool getInspectionTool() {
+    protected AbstractInspection getInspectionTool() {
         return kotlin ? new GradleKotlinInspection() : new GradleGroovyInspection();
     }
 

--- a/src/main/java/com/jfrog/ide/idea/scan/MavenScanManager.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/MavenScanManager.java
@@ -1,7 +1,6 @@
 package com.jfrog.ide.idea.scan;
 
 import com.google.common.collect.Sets;
-import com.intellij.codeInspection.LocalInspectionTool;
 import com.intellij.ide.highlighter.XmlFileType;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Pair;
@@ -10,6 +9,7 @@ import com.intellij.psi.PsiFile;
 import com.intellij.psi.search.FilenameIndex;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.jfrog.ide.common.scan.ComponentPrefix;
+import com.jfrog.ide.idea.inspections.AbstractInspection;
 import com.jfrog.ide.idea.inspections.MavenInspection;
 import com.jfrog.ide.idea.ui.ComponentsTree;
 import com.jfrog.ide.idea.ui.menus.filtermanager.ConsistentFilterManager;
@@ -92,7 +92,7 @@ public class MavenScanManager extends ScanManager {
     }
 
     @Override
-    protected LocalInspectionTool getInspectionTool() {
+    protected AbstractInspection getInspectionTool() {
         return new MavenInspection();
     }
 

--- a/src/main/java/com/jfrog/ide/idea/scan/NpmScanManager.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/NpmScanManager.java
@@ -1,6 +1,5 @@
 package com.jfrog.ide.idea.scan;
 
-import com.intellij.codeInspection.LocalInspectionTool;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -9,6 +8,7 @@ import com.intellij.psi.PsiManager;
 import com.intellij.util.EnvironmentUtil;
 import com.jfrog.ide.common.npm.NpmTreeBuilder;
 import com.jfrog.ide.common.scan.ComponentPrefix;
+import com.jfrog.ide.idea.inspections.AbstractInspection;
 import com.jfrog.ide.idea.inspections.NpmInspection;
 import com.jfrog.ide.idea.ui.ComponentsTree;
 import com.jfrog.ide.idea.ui.menus.filtermanager.ConsistentFilterManager;
@@ -55,7 +55,7 @@ public class NpmScanManager extends ScanManager {
     }
 
     @Override
-    protected LocalInspectionTool getInspectionTool() {
+    protected AbstractInspection getInspectionTool() {
         return new NpmInspection();
     }
 
@@ -64,4 +64,3 @@ public class NpmScanManager extends ScanManager {
         return PKG_TYPE;
     }
 }
-

--- a/src/main/java/com/jfrog/ide/idea/scan/PypiScanManager.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/PypiScanManager.java
@@ -1,7 +1,6 @@
 package com.jfrog.ide.idea.scan;
 
 import com.google.common.collect.Sets;
-import com.intellij.codeInspection.LocalInspectionTool;
 import com.intellij.execution.ExecutionException;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.projectRoots.Sdk;
@@ -13,6 +12,7 @@ import com.jetbrains.python.packaging.PyRequirement;
 import com.jetbrains.python.packaging.pipenv.PyPipEnvPackageManager;
 import com.jetbrains.python.sdk.PythonSdkUtil;
 import com.jfrog.ide.common.scan.ComponentPrefix;
+import com.jfrog.ide.idea.inspections.AbstractInspection;
 import com.jfrog.ide.idea.ui.ComponentsTree;
 import com.jfrog.ide.idea.ui.menus.filtermanager.ConsistentFilterManager;
 import org.apache.commons.collections4.CollectionUtils;
@@ -167,7 +167,7 @@ public class PypiScanManager extends ScanManager {
     }
 
     @Override
-    protected LocalInspectionTool getInspectionTool() {
+    protected AbstractInspection getInspectionTool() {
         return null;
     }
 

--- a/src/main/java/com/jfrog/ide/idea/scan/ScanManager.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ScanManager.java
@@ -29,6 +29,7 @@ import com.jfrog.ide.common.scan.ScanManagerBase;
 import com.jfrog.ide.common.utils.ProjectsMap;
 import com.jfrog.ide.idea.configuration.GlobalSettings;
 import com.jfrog.ide.idea.events.ProjectEvents;
+import com.jfrog.ide.idea.inspections.AbstractInspection;
 import com.jfrog.ide.idea.log.Logger;
 import com.jfrog.ide.idea.log.ProgressIndicatorImpl;
 import com.jfrog.ide.idea.ui.ComponentsTree;
@@ -110,7 +111,7 @@ public abstract class ScanManager extends ScanManagerBase implements Disposable 
      *
      * @return the Inspection tool corresponding to the scan-manager type.
      */
-    protected abstract LocalInspectionTool getInspectionTool();
+    protected abstract AbstractInspection getInspectionTool();
 
     protected void sendUsageReport() {
         Utils.sendUsageReport(getProjectPackageType() + "-deps");
@@ -260,7 +261,8 @@ public abstract class ScanManager extends ScanManagerBase implements Disposable 
         }
         InspectionManagerEx inspectionManagerEx = (InspectionManagerEx) InspectionManager.getInstance(project);
         GlobalInspectionContext context = inspectionManagerEx.createNewGlobalContext(false);
-        LocalInspectionTool localInspectionTool = getInspectionTool();
+        AbstractInspection localInspectionTool = getInspectionTool();
+        localInspectionTool.setAfterScan(true);
         for (PsiFile descriptor : projectDescriptors) {
             // Run inspection on descriptor.
             InspectionEngine.runInspectionOnFile(descriptor, new LocalInspectionToolWrapper(localInspectionTool), context);

--- a/src/main/java/com/jfrog/ide/idea/scan/YarnScanManager.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/YarnScanManager.java
@@ -1,15 +1,14 @@
 package com.jfrog.ide.idea.scan;
 
-import com.intellij.codeInspection.LocalInspectionTool;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiManager;
 import com.intellij.util.EnvironmentUtil;
-import com.jfrog.ide.common.npm.NpmTreeBuilder;
 import com.jfrog.ide.common.scan.ComponentPrefix;
 import com.jfrog.ide.common.yarn.YarnTreeBuilder;
+import com.jfrog.ide.idea.inspections.AbstractInspection;
 import com.jfrog.ide.idea.inspections.NpmInspection;
 import com.jfrog.ide.idea.ui.ComponentsTree;
 import com.jfrog.ide.idea.ui.menus.filtermanager.ConsistentFilterManager;
@@ -56,7 +55,7 @@ public class YarnScanManager extends ScanManager {
     }
 
     @Override
-    protected LocalInspectionTool getInspectionTool() {
+    protected AbstractInspection getInspectionTool() {
         return new NpmInspection();
     }
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----

Resolve #231 

The NavigationService gets populated after the code inspection. Code inspections may run after one of the 3 following options:
1. The project descriptor (like pom.xml) was opened.
2. The user manually triggered code inspection by clicking on "Code | Inspect Code" - we intentionally skip our code inspections in this case (see https://github.com/jfrog/jfrog-idea-plugin/pull/186).
3. An Xray scan was completed - we accidentally skip code inspections in this case.

This PR makes sure that in the 3rd option, the code inspections are not skipped.