### PR TITLE
Bugfix - Illegal chars error when using a watch with period

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/ui/configuration/ConfigVerificationUtils.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/configuration/ConfigVerificationUtils.java
@@ -54,6 +54,6 @@ public class ConfigVerificationUtils {
     }
 
     private static boolean illegalCharactersExist(String str) {
-        return !str.matches("[\\w-]*");
+        return !str.matches("[\\w-.]*");
     }
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----

Fixes https://github.com/jfrog/jfrog-idea-plugin/issues/231#issuecomment-1291760356

Fix the following issue when trying to save a watch with ".":\
![image](https://user-images.githubusercontent.com/11367982/198002647-49e10028-e178-4a81-8735-d5320b379ae5.png)
