### PR TITLE
Fix exception from Inspector

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/inspections/AbstractInspection.java
+++ b/src/main/java/com/jfrog/ide/idea/inspections/AbstractInspection.java
@@ -65,7 +65,9 @@ public abstract class AbstractInspection extends LocalInspectionTool implements 
         }
         NavigationService navigationService = NavigationService.getInstance(element.getProject());
         for (DependencyTree dependency : dependencies) {
-            InspectionUtils.registerProblem(problemsHolder, dependency, getTargetElements(element), dependencies.size());
+            if (isOnTheFly) {
+                InspectionUtils.registerProblem(problemsHolder, dependency, getTargetElements(element), dependencies.size());
+            }
             navigationService.addNavigation(dependency, element);
         }
     }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----

Fix the following exception:
```
com.intellij.diagnostic.PluginException: Tool #Maven (class com.jfrog.ide.idea.inspections.MavenInspection) registers 'INFORMATION'-level problem in batch mode on XmlFile:pom.xml. Warnings of the 'INFORMATION' level are invisible in the editor and should not become visible in batch mode. Moreover, since 'INFORMATION'-level fixes act more like intention actions, they could e.g. change semantics and thus should not be suggested for batch transformations [Plugin: org.jfrog.idea]
	at com.intellij.codeInspection.InspectionEngine$2.registerProblem(InspectionEngine.java:261)
	at com.intellij.codeInspection.ProblemsHolder.registerProblem(ProblemsHolder.java:52)
```

After an Xray scan, we trigger inspections on the project descriptors, to allow navigating from the dependency tree to the dependency in the project descriptor.
Currently, we also add navigation in the opposite way - from the project descriptor to the dependency tree. Adding this kind of inspection does not make sense when the file is closed and throws a (harmless) exception.
This PR makes sure that only when a user opens the project descriptor, it will add the navigation to the tree.