### PR TITLE
Bugfix - Stackoverflow when reading credentials from CLI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,9 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: '3.x'
+      # Install JFrog CLI for ConnectionDetailsFromCliTest
+      - name: Install JFrog CLI
+        run: curl -fL https://install-cli.jfrog.io | sh
 
       # Run tests
       - name: Tests on macOS, Linux

--- a/src/main/java/com/jfrog/ide/idea/configuration/ServerConfigImpl.java
+++ b/src/main/java/com/jfrog/ide/idea/configuration/ServerConfigImpl.java
@@ -497,7 +497,7 @@ public class ServerConfigImpl implements ServerConfig {
         String passwordCli = cliServerConfig.getPassword();
         String accessToken = cliServerConfig.getAccessToken();
 
-        if ((isAnyBlank(usernameCli, passwordCli) && isBlank(accessToken)) || isAllBlank(platformUrlCLi, xrayUrlCli, artifactoryUrlCli)) {
+        if ((isAnyBlank(usernameCli, passwordCli) && isBlank(accessToken)) || isAnyBlank(xrayUrlCli, artifactoryUrlCli)) {
             return false;
         }
         setUrl(platformUrlCLi);

--- a/src/main/java/com/jfrog/ide/idea/configuration/ServerConfigImpl.java
+++ b/src/main/java/com/jfrog/ide/idea/configuration/ServerConfigImpl.java
@@ -490,17 +490,17 @@ public class ServerConfigImpl implements ServerConfig {
             return false;
         }
         JfrogCliServerConfig cliServerConfig = driver.getServerConfig();
-        String platformUrlCLi = cliServerConfig.getUrl();
+        String platformUrlCli = cliServerConfig.getUrl();
         String xrayUrlCli = cliServerConfig.getXrayUrl();
         String artifactoryUrlCli = cliServerConfig.getArtifactoryUrl();
         String usernameCli = cliServerConfig.getUsername();
         String passwordCli = cliServerConfig.getPassword();
         String accessToken = cliServerConfig.getAccessToken();
 
-        if ((isAnyBlank(usernameCli, passwordCli) && isBlank(accessToken)) || isAnyBlank(xrayUrlCli, artifactoryUrlCli)) {
+        if ((isAnyBlank(usernameCli, passwordCli) && isBlank(accessToken)) || isAnyBlank(platformUrlCli, xrayUrlCli, artifactoryUrlCli)) {
             return false;
         }
-        setUrl(platformUrlCLi);
+        setUrl(platformUrlCli);
         setXrayUrl(xrayUrlCli);
         setArtifactoryUrl(artifactoryUrlCli);
         setUsername(usernameCli);

--- a/src/test/java/com/jfrog/ide/idea/configuration/ConnectionDetailsFromCliTest.java
+++ b/src/test/java/com/jfrog/ide/idea/configuration/ConnectionDetailsFromCliTest.java
@@ -24,20 +24,20 @@ import static org.junit.Assert.assertEquals;
 public class ConnectionDetailsFromCliTest {
 
     private final String[] cliParameters;
-    private final Exception exception;
-    private final boolean expected;
+    private final Exception expectedException;
+    private final boolean shouldSuccess;
 
-    public ConnectionDetailsFromCliTest(String[] cliParameters, Exception exception, boolean expected) {
+    public ConnectionDetailsFromCliTest(String[] cliParameters, Exception expectedException, boolean shouldSuccess) {
         this.cliParameters = cliParameters;
-        this.exception = exception;
-        this.expected = expected;
+        this.expectedException = expectedException;
+        this.shouldSuccess = shouldSuccess;
     }
 
     @Parameterized.Parameters
     public static Collection<Object[]> dataProvider() {
         return Arrays.asList(new Object[][]{
                 // No JFrog CLI config
-                {null, new IOException("jfrog config export command failed. That might be happen if you haven't config any CLI server yet or using the config encryption feature."), false},
+                {null, new IOException("'jfrog config export' command failed. That might be happen if you haven't config any CLI server yet or using the config encryption feature."), false},
 
                 // URLs without credentials
                 {new String[]{"c", "add", "--xray-url=http://127.0.0.1"}, null, false},
@@ -77,10 +77,10 @@ public class ConnectionDetailsFromCliTest {
 
             // Check results
             ServerConfigImpl serverConfig = new ServerConfigImpl();
-            if (exception != null) {
-                Assert.assertThrows(exception.getMessage(), exception.getClass(), serverConfig::readConnectionDetailsFromJfrogCli);
+            if (expectedException != null) {
+                Assert.assertThrows(expectedException.getMessage(), expectedException.getClass(), serverConfig::readConnectionDetailsFromJfrogCli);
             } else {
-                assertEquals(expected, serverConfig.readConnectionDetailsFromJfrogCli());
+                assertEquals(shouldSuccess, serverConfig.readConnectionDetailsFromJfrogCli());
             }
         } finally {
             FileUtils.forceDelete(jfrogCliHome.toFile());

--- a/src/test/java/com/jfrog/ide/idea/configuration/ConnectionDetailsFromCliTest.java
+++ b/src/test/java/com/jfrog/ide/idea/configuration/ConnectionDetailsFromCliTest.java
@@ -1,0 +1,89 @@
+package com.jfrog.ide.idea.configuration;
+
+import com.intellij.util.EnvironmentUtil;
+import com.jfrog.ide.common.configuration.JfrogCliDriver;
+import org.apache.commons.io.FileUtils;
+import org.gradle.internal.impldep.org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author yahavi
+ **/
+@RunWith(Parameterized.class)
+public class ConnectionDetailsFromCliTest {
+
+    private final String[] cliParameters;
+    private final Exception exception;
+    private final boolean expected;
+
+    public ConnectionDetailsFromCliTest(String[] cliParameters, Exception exception, boolean expected) {
+        this.cliParameters = cliParameters;
+        this.exception = exception;
+        this.expected = expected;
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> dataProvider() {
+        return Arrays.asList(new Object[][]{
+                // No JFrog CLI config
+                {null, new IOException("jfrog config export command failed. That might be happen if you haven't config any CLI server yet or using the config encryption feature."), false},
+
+                // URLs without credentials
+                {new String[]{"c", "add", "--xray-url=http://127.0.0.1"}, null, false},
+                {new String[]{"c", "add", "--artifactory-url=http://127.0.0.1"}, null, false},
+
+                // Credentials without URLs
+                {new String[]{"c", "add", "--user=admin"}, null, false},
+                {new String[]{"c", "add", "--user=admin", "--password=password"}, null, false},
+                {new String[]{"c", "add", "--access-token=123"}, null, false},
+
+                // Partial URLs
+                {new String[]{"c", "add", "--artifactory-url=http://127.0.0.1:8081/artifactory", "--user=admin", "--password=password", "--enc-password=false"}, null, false},
+                {new String[]{"c", "add", "--xray-url=http://127.0.0.1:8081/xray", "--user=admin", "--password=password", "--enc-password=false"}, null, false},
+
+                // Positive tests
+                {new String[]{"c", "add", "--url=http://127.0.0.1:8081", "--user=admin", "--password=password", "--enc-password=false"}, null, true},
+                {new String[]{"c", "add", "--url=http://127.0.0.1:8081", "--access-token=123"}, null, true},
+        });
+    }
+
+    @Test
+    public void testReadConnectionDetailsFromJfrogCli() throws IOException, InterruptedException {
+        Path jfrogCliHome = Files.createTempDirectory("testReadConnectionDetailsFromJfrogCli");
+        try (MockedStatic<EnvironmentUtil> mockController = Mockito.mockStatic(EnvironmentUtil.class)) {
+            // Set environment variables
+            Map<String, String> envVars = new HashMap<>(System.getenv()) {{
+                put("JFROG_CLI_HOME_DIR", jfrogCliHome.toAbsolutePath().toString());
+                put("CI", "true");
+            }};
+            mockController.when(EnvironmentUtil::getEnvironmentMap).thenReturn(envVars);
+
+            // Config JFrog CLI
+            if (cliParameters != null) {
+                JfrogCliDriver jfrogCliDriver = new JfrogCliDriver(envVars);
+                jfrogCliDriver.runCommand(null, cliParameters, new ArrayList<>(), null);
+            }
+
+            // Check results
+            ServerConfigImpl serverConfig = new ServerConfigImpl();
+            if (exception != null) {
+                Assert.assertThrows(exception.getMessage(), exception.getClass(), serverConfig::readConnectionDetailsFromJfrogCli);
+            } else {
+                assertEquals(expected, serverConfig.readConnectionDetailsFromJfrogCli());
+            }
+        } finally {
+            FileUtils.forceDelete(jfrogCliHome.toFile());
+        }
+    }
+}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----

Depends on: https://github.com/jfrog/ide-plugins-common/pull/87

In the following use-case, reading credentials from the JFrog CLI cause infinite recursion:
1. Delete credentials in JFrog IDEA plugin configuration.
2. Configure default JFrog CLI server with Artifactory URL only: 
  `jf c add --artifactory-url=https://acme.jfrog.io/artifactory --user=frogger --password=super-secret`
3. Trigger Xray scan in the JFrog IDEA plugin.

Results:

> java.lang.StackOverflowError
	at java.base/java.util.concurrent.SynchronousQueue$TransferStack.transfer(SynchronousQueue.java:382)
	at java.base/java.util.concurrent.SynchronousQueue.offer(SynchronousQueue.java:909)
	at java.base/java.util.concurrent.ThreadPoolExecutor.execute(ThreadPoolExecutor.java:1347)
	at java.base/java.lang.ProcessHandleImpl.completion(ProcessHandleImpl.java:135)
	at java.base/java.lang.ProcessImpl.initStreams(ProcessImpl.java:389)
	at java.base/java.lang.ProcessImpl.lambda$new$0(ProcessImpl.java:352)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/java.lang.ProcessImpl.<init>(ProcessImpl.java:351)
	at java.base/java.lang.ProcessImpl.start(ProcessImpl.java:271)
	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1107)
	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1071)
	at java.base/java.lang.Runtime.exec(Runtime.java:592)
	at org.jfrog.build.extractor.executor.CommandExecutor.runProcess(CommandExecutor.java:169)
	at org.jfrog.build.extractor.executor.CommandExecutor.exeCommand(CommandExecutor.java:122)
	at com.jfrog.ide.common.configuration.JfrogCliDriver.runCommand(JfrogCliDriver.java:84)
	at com.jfrog.ide.common.configuration.JfrogCliDriver.runCommand(JfrogCliDriver.java:79)
	at com.jfrog.ide.common.configuration.JfrogCliDriver.version(JfrogCliDriver.java:75)
	at com.jfrog.ide.common.configuration.JfrogCliDriver.isJfrogCliInstalled(JfrogCliDriver.java:42)
	at com.jfrog.ide.idea.configuration.ServerConfigImpl.readConnectionDetailsFromJfrogCli(ServerConfigImpl.java:489)
	at com.jfrog.ide.idea.configuration.GlobalSettings.loadConnectionDetailsFromJfrogCli(GlobalSettings.java:208)
	at com.jfrog.ide.idea.scan.ScanManagersFactory.tryConnectionDetailsFromJfrogCli(ScanManagersFactory.java:119)
	at com.jfrog.ide.idea.scan.ScanManagersFactory.startScan(ScanManagersFactory.java:91)
	at com.jfrog.ide.idea.scan.ScanManagersFactory.lambda$registerOnChangeHandlers$0(ScanManagersFactory.java:72)
	at com.intellij.util.messages.impl.MessageBusImpl.invokeMethod(MessageBusImpl.java:671)
	at com.intellij.util.messages.impl.MessageBusImpl.invokeListener(MessageBusImpl.java:649)
	at com.intellij.util.messages.impl.MessageBusImpl.deliverMessage(MessageBusImpl.java:422)
	at com.intellij.util.messages.impl.MessageBusImpl.pumpWaitingBuses(MessageBusImpl.java:397)
	at com.intellij.util.messages.impl.MessageBusImpl.pumpMessages(MessageBusImpl.java:379)
	at com.intellij.util.messages.impl.MessageBusImpl.access$100(MessageBusImpl.java:33)
	at com.intellij.util.messages.impl.MessageBusImpl$MessagePublisher.invoke(MessageBusImpl.java:185)
	at com.sun.proxy.$Proxy219.update(Unknown Source)
	at com.jfrog.ide.idea.scan.ScanManagersFactory.tryConnectionDetailsFromJfrogCli(ScanManagersFactory.java:125)
	at com.jfrog.ide.idea.scan.ScanManagersFactory.startScan(ScanManagersFactory.java:91)
	at com.jfrog.ide.idea.scan.ScanManagersFactory.lambda$registerOnChangeHandlers$0(ScanManagersFactory.java:72)
	at com.intellij.util.messages.impl.MessageBusImpl.invokeMethod(MessageBusImpl.java:671)
	at com.intellij.util.messages.impl.MessageBusImpl.invokeListener(MessageBusImpl.java:649)
	at com.intellij.util.messages.impl.MessageBusImpl.deliverMessage(MessageBusImpl.java:422)
	at com.intellij.util.messages.impl.MessageBusImpl.pumpWaitingBuses(MessageBusImpl.java:397)
	at com.intellij.util.messages.impl.MessageBusImpl.pumpMessages(MessageBusImpl.java:379)
	at com.intellij.util.messages.impl.MessageBusImpl.access$100(MessageBusImpl.java:33)
	at com.intellij.util.messages.impl.MessageBusImpl$MessagePublisher.invoke(MessageBusImpl.java:185)
	at com.sun.proxy.$Proxy219.update(Unknown Source)