### PR TITLE
Read from cache when triggering a scan by the "Refresh Scan" button

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/actions/RefreshLocalAction.java
+++ b/src/main/java/com/jfrog/ide/idea/actions/RefreshLocalAction.java
@@ -14,6 +14,6 @@ public class RefreshLocalAction extends AnAction {
         if (e.getProject() == null) {
             return;
         }
-        ScanManagersFactory.getInstance(e.getProject()).startScan(false);
+        ScanManagersFactory.getInstance(e.getProject()).startScan(true, true);
     }
 }

--- a/src/main/java/com/jfrog/ide/idea/scan/ScanManager.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ScanManager.java
@@ -129,7 +129,7 @@ public abstract class ScanManager extends ScanManagerBase implements Disposable 
     private void scanAndUpdate(boolean quickScan, boolean shouldToast, ProgressIndicator indicator) {
         try {
             indicator.setText("1/3: Building dependency tree");
-            buildTree(!shouldToast);
+            buildTree(shouldToast);
             indicator.setText("2/3: Xray scanning project dependencies");
             scanAndCacheArtifacts(indicator, quickScan);
             indicator.setText("3/3: Finalizing");
@@ -139,7 +139,7 @@ public abstract class ScanManager extends ScanManagerBase implements Disposable 
         } catch (ProcessCanceledException e) {
             getLog().info("Xray scan was canceled");
         } catch (Exception e) {
-            logError(getLog(), "Xray Scan failed", e, !shouldToast);
+            logError(getLog(), "Xray Scan failed", e, shouldToast);
         } finally {
             scanInProgress.set(false);
             sendUsageReport();
@@ -171,7 +171,7 @@ public abstract class ScanManager extends ScanManagerBase implements Disposable 
                 }
                 // Prevent multiple simultaneous scans
                 if (!scanInProgress.compareAndSet(false, true)) {
-                    if (!shouldToast) {
+                    if (shouldToast) {
                         getLog().info("Scan already in progress");
                     }
                     return;
@@ -234,7 +234,7 @@ public abstract class ScanManager extends ScanManagerBase implements Disposable 
                     latch.await();
                 }
             } catch (InterruptedException e) {
-                logError(getLog(), ExceptionUtils.getRootCauseMessage(e), e, !shouldToast);
+                logError(getLog(), ExceptionUtils.getRootCauseMessage(e), e, shouldToast);
             }
         };
     }

--- a/src/main/java/com/jfrog/ide/idea/scan/ScanManagersFactory.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ScanManagersFactory.java
@@ -101,11 +101,11 @@ public class ScanManagersFactory implements Disposable {
                 try {
                     scanManager.asyncScanAndUpdateResults(quickScan, shouldToast);
                 } catch (RuntimeException e) {
-                    logError(Logger.getInstance(), "", e, !shouldToast);
+                    logError(Logger.getInstance(), "", e, shouldToast);
                 }
             }
         } catch (IOException | RuntimeException | InterruptedException e) {
-            logError(Logger.getInstance(), "", e, !shouldToast);
+            logError(Logger.getInstance(), "", e, shouldToast);
         } finally {
             executor.shutdown();
         }

--- a/src/main/java/com/jfrog/ide/idea/scan/ScanManagersFactory.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ScanManagersFactory.java
@@ -68,15 +68,16 @@ public class ScanManagersFactory implements Disposable {
      * Therefore, we run startScan() which recreates the scan managers on refreshScanManagers().
      */
     private void registerOnChangeHandlers() {
-        busConnection.subscribe(ApplicationEvents.ON_CONFIGURATION_DETAILS_CHANGE, () -> startScan(false));
+        busConnection.subscribe(ApplicationEvents.ON_CONFIGURATION_DETAILS_CHANGE, () -> startScan(false, true));
     }
 
     /**
      * Start an Xray scan for all projects.
      *
-     * @param quickScan - True to allow usage of the scan cache.
+     * @param quickScan   - True to allow usage of the scan cache.
+     * @param shouldToast - True to enable showing balloons logs.
      */
-    public void startScan(boolean quickScan) {
+    public void startScan(boolean quickScan, boolean shouldToast) {
         if (DumbService.isDumb(project)) { // If intellij is still indexing the project
             return;
         }
@@ -98,13 +99,13 @@ public class ScanManagersFactory implements Disposable {
             NavigationService.clearNavigationMap(project);
             for (ScanManager scanManager : scanManagers.values()) {
                 try {
-                    scanManager.asyncScanAndUpdateResults(quickScan);
+                    scanManager.asyncScanAndUpdateResults(quickScan, shouldToast);
                 } catch (RuntimeException e) {
-                    logError(Logger.getInstance(), "", e, !quickScan);
+                    logError(Logger.getInstance(), "", e, !shouldToast);
                 }
             }
         } catch (IOException | RuntimeException | InterruptedException e) {
-            logError(Logger.getInstance(), "", e, !quickScan);
+            logError(Logger.getInstance(), "", e, !shouldToast);
         } finally {
             executor.shutdown();
         }

--- a/src/main/java/com/jfrog/ide/idea/ui/JFrogToolWindowFactory.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/JFrogToolWindowFactory.java
@@ -26,7 +26,7 @@ public class JFrogToolWindowFactory implements ToolWindowFactory {
         boolean buildsConfigured = isBuildsConfigured(project);
         DumbService.getInstance(project).runWhenSmart(() -> {
             project.getService(JFrogToolWindow.class).initToolWindow(toolWindow, project, localProjectSupported, buildsConfigured);
-            ScanManagersFactory.getInstance(project).startScan(true);
+            ScanManagersFactory.getInstance(project).startScan(true, false);
             CiManager.getInstance(project).asyncRefreshBuilds(true);
         });
     }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----

When a user clicks on the "Refresh Scan" button, read Xray scan results from caches rather than sending REST requests to Xray every time.
This should reduce the load on either server side and dramatically improve the performance of the "Refresh Scan" button.

After this change, we will send a REST to the Xray server in one of the following scenarios:
1. Changing the server configuration (like changing the server URL or the Watch) 
2. If a dependency is invalidated (older than 1 week)