### PR TITLE
Incorrect fixed versions in Poetry

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/scan/PypiScanManager.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/PypiScanManager.java
@@ -129,8 +129,7 @@ public class PypiScanManager extends SingleDescriptorScanManager {
      * @param dependencyMapping - dependency name to Python package mapping
      */
     void populateDependencyTree(DependencyTree node, PyPackage pyPackage, Map<String, PyPackage> dependencyMapping) {
-        String unresolved = pyPackage.isInstalled() ? "" : " [Unresolved]";
-        DependencyTree child = new DependencyTree(pyPackage.getName() + ":" + pyPackage.getVersion() + unresolved);
+        DependencyTree child = new DependencyTree(pyPackage.getName() + ":" + pyPackage.getVersion());
         initDependencyNode(child, pyPackage.getName(), pyPackage.getVersion(), "", "pypi");
         node.add(child);
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----

**Problem**
Currently in python, when there is an unresolved dependency, we add `[Unresolved]` suffix in the component ID. The problem is that this prefix is sent to Xray. As a result, Xray returned an unexpected result.

**Solution**
This PR fixes this issue by removing the `[Unresolved]` suffix from the dependency tree. 

**Justifications**
1. The new UI doesn't show the dependency tree and it is confusing to display `[Unresolved]` only in the vulnerable components.
2. We will find a better way to display not-installed projects.
