### PR TITLE
V1: Skip loading cache from file-system in full scan mode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     implementation group: 'com.jfrog.xray.client', name: 'xray-client-java', version: '0.11.0'
     implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
     implementation group: 'org.jfrog.filespecs', name: 'file-specs-java', version: '1.1.2'
-    implementation group: 'com.jfrog.ide', name: 'ide-plugins-common', version: '1.13.3'
+    implementation group: 'com.jfrog.ide', name: 'ide-plugins-common', version: '1.13.4'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.11'
     implementation group: 'com.google.guava', name: 'guava', version: '30.1.1-jre'
 

--- a/src/main/java/com/jfrog/ide/idea/scan/ScanManager.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ScanManager.java
@@ -130,7 +130,7 @@ public abstract class ScanManager extends ScanManagerBase implements Disposable 
             indicator.setText("1/3: Building dependency tree");
             buildTree(!quickScan);
             indicator.setText("2/3: Xray scanning project dependencies");
-            scanAndCacheArtifacts(indicator, quickScan);
+            scanAndCacheArtifacts(indicator);
             indicator.setText("3/3: Finalizing");
             addXrayInfoToTree(getScanResults());
             setScanResults();

--- a/src/test/java/com/jfrog/ide/idea/scan/PypiScanManagerTest.java
+++ b/src/test/java/com/jfrog/ide/idea/scan/PypiScanManagerTest.java
@@ -108,7 +108,7 @@ public class PypiScanManagerTest extends LightJavaCodeInsightFixtureTestCase {
 
     public void testBuildTree() throws IOException {
         PypiScanManager pypiScanManager = new PypiScanManager(getProject(), pythonSdk, executorService);
-        pypiScanManager.setScanLogic(new ComponentSummaryScanLogic(new XrayScanCache(getProject().getName(), HOME_PATH.resolve("cache"), new NullLog()), new NullLog()));
+        pypiScanManager.setScanLogic(new ComponentSummaryScanLogic(new XrayScanCache(getProject().getName(), HOME_PATH.resolve("cache"), false, new NullLog()), new NullLog()));
         pypiScanManager.buildTree(false);
 
         // Check root SDK node

--- a/src/test/java/com/jfrog/ide/idea/scan/ScanManagersTest.java
+++ b/src/test/java/com/jfrog/ide/idea/scan/ScanManagersTest.java
@@ -44,7 +44,7 @@ public class ScanManagersTest extends TestCase {
         myFixture = fixtureBuilder.getFixture();
         myFixture.setUp();
         scanManagersFactory = ScanManagersFactory.getInstance(myFixture.getProject());
-        scanManagersFactory.refreshScanManagers(Utils.ScanLogicType.GraphScan, null);
+        scanManagersFactory.refreshScanManagers(Utils.ScanLogicType.GraphScan, null, false);
     }
 
     @Override


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----

Resolves https://github.com/jfrog/jfrog-idea-plugin/issues/248
Depends on https://github.com/jfrog/ide-plugins-common/pull/101

When changing watches, the cache does not get updated.
This PR changes the way we initialize the scan cache in case of a full scan, by avoiding reading the cache from the file system.