### PR TITLE
V1 : Support usage report with access token

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/utils/Utils.java
+++ b/src/main/java/com/jfrog/ide/idea/utils/Utils.java
@@ -106,7 +106,7 @@ public class Utils {
         String pluginVersion = jfrogPlugin.getVersion();
         UsageReporter usageReporter = new UsageReporter(PRODUCT_ID + pluginVersion, featureIdArray);
         try {
-            usageReporter.reportUsage(serverConfig.getArtifactoryUrl(), serverConfig.getUsername(), serverConfig.getPassword(), "", null, log);
+            usageReporter.reportUsage(serverConfig.getArtifactoryUrl(), serverConfig.getUsername(), serverConfig.getPassword(), serverConfig.getAccessToken(), null, log);
         } catch (IOException e) {
             log.debug("Usage report failed: " + ExceptionUtils.getRootCauseMessage(e));
         }


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
Fixes usage report sending when authentication is done with an access token.