### PR TITLE
V1: Watches are ignored when reading creds from env

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     implementation group: 'com.jfrog.xray.client', name: 'xray-client-java', version: '0.11.0'
     implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
     implementation group: 'org.jfrog.filespecs', name: 'file-specs-java', version: '1.1.2'
-    implementation group: 'com.jfrog.ide', name: 'ide-plugins-common', version: '1.13.3'
+    implementation group: 'com.jfrog.ide', name: 'ide-plugins-common', version: '1.13.4'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.11'
     implementation group: 'com.google.guava', name: 'guava', version: '30.1.1-jre'
 

--- a/src/main/java/com/jfrog/ide/idea/configuration/GlobalSettings.java
+++ b/src/main/java/com/jfrog/ide/idea/configuration/GlobalSettings.java
@@ -132,10 +132,8 @@ public final class GlobalSettings implements PersistentStateComponent<GlobalSett
     public void setServerConfig(@NotNull ServerConfigImpl serverConfig) {
         if (serverConfig.isConnectionDetailsFromEnv()) {
             // Load connection details from environment variables.
+            setAdvancedSettings(serverConfig);
             this.serverConfig.setConnectionDetailsFromEnv(this.serverConfig.readConnectionDetailsFromEnv());
-            this.serverConfig.setExcludedPaths(serverConfig.getExcludedPaths());
-            this.serverConfig.setConnectionRetries(serverConfig.getConnectionRetries());
-            this.serverConfig.setConnectionTimeout(serverConfig.getConnectionTimeout());
             return;
         }
 
@@ -156,10 +154,7 @@ public final class GlobalSettings implements PersistentStateComponent<GlobalSett
             }
             this.serverConfig.setConnectionDetailsFromEnv(true);
             this.serverConfig.readConnectionDetailsFromEnv();
-            this.serverConfig.setExcludedPaths(serverConfig.getExcludedPaths());
-            this.serverConfig.setProject(serverConfig.getProject());
-            this.serverConfig.setConnectionRetries(serverConfig.getConnectionRetries());
-            this.serverConfig.setConnectionTimeout(serverConfig.getConnectionTimeout());
+            setAdvancedSettings(serverConfig);
             return;
         }
 
@@ -177,15 +172,19 @@ public final class GlobalSettings implements PersistentStateComponent<GlobalSett
         this.serverConfig.setUrl(serverConfig.getUrl());
         this.serverConfig.setXrayUrl(serverConfig.getXrayUrl());
         this.serverConfig.setArtifactoryUrl(serverConfig.getArtifactoryUrl());
+        this.serverConfig.setConnectionDetailsFromEnv(serverConfig.isConnectionDetailsFromEnv());
+        this.serverConfig.setJFrogSettingsCredentialsKey(serverConfig.getJFrogSettingsCredentialsKey());
+        this.serverConfig.setXraySettingsCredentialsKey(serverConfig.getXraySettingsCredentialsKey());
+        setAdvancedSettings(serverConfig);
+    }
+
+    private void setAdvancedSettings(ServerConfigImpl serverConfig) {
         this.serverConfig.setExcludedPaths(serverConfig.getExcludedPaths());
+        this.serverConfig.setConnectionRetries(serverConfig.getConnectionRetries());
+        this.serverConfig.setConnectionTimeout(serverConfig.getConnectionTimeout());
         this.serverConfig.setPolicyType(serverConfig.getPolicyType());
         this.serverConfig.setProject(serverConfig.getProject());
         this.serverConfig.setWatches(serverConfig.getWatches());
-        this.serverConfig.setConnectionDetailsFromEnv(serverConfig.isConnectionDetailsFromEnv());
-        this.serverConfig.setConnectionRetries(serverConfig.getConnectionRetries());
-        this.serverConfig.setConnectionTimeout(serverConfig.getConnectionTimeout());
-        this.serverConfig.setJFrogSettingsCredentialsKey(serverConfig.getJFrogSettingsCredentialsKey());
-        this.serverConfig.setXraySettingsCredentialsKey(serverConfig.getXraySettingsCredentialsKey());
     }
 
     public boolean areXrayCredentialsSet() {

--- a/src/test/java/com/jfrog/ide/idea/configuration/ConfigurationTest.java
+++ b/src/test/java/com/jfrog/ide/idea/configuration/ConfigurationTest.java
@@ -145,6 +145,8 @@ public class ConfigurationTest extends LightJavaCodeInsightFixtureTestCase {
             assertEquals(CONNECTION_RETRIES, actualServerConfig.getConnectionRetries());
             assertEquals(CONNECTION_TIMEOUT, actualServerConfig.getConnectionTimeout());
             assertEquals(EXCLUDED_PATHS, actualServerConfig.getExcludedPaths());
+            assertEquals(JFROG_PROJECT, actualServerConfig.getProject());
+            assertEquals(WATCH, actualServerConfig.getWatches());
         }
     }
 
@@ -177,6 +179,8 @@ public class ConfigurationTest extends LightJavaCodeInsightFixtureTestCase {
             assertEquals(CONNECTION_RETRIES, actualServerConfig.getConnectionRetries());
             assertEquals(CONNECTION_TIMEOUT, actualServerConfig.getConnectionTimeout());
             assertEquals(EXCLUDED_PATHS, actualServerConfig.getExcludedPaths());
+            assertEquals(JFROG_PROJECT, actualServerConfig.getProject());
+            assertEquals(WATCH, actualServerConfig.getWatches());
         }
     }
 
@@ -213,6 +217,8 @@ public class ConfigurationTest extends LightJavaCodeInsightFixtureTestCase {
             assertEquals(CONNECTION_RETRIES, actualServerConfig.getConnectionRetries());
             assertEquals(CONNECTION_TIMEOUT, actualServerConfig.getConnectionTimeout());
             assertEquals(EXCLUDED_PATHS, actualServerConfig.getExcludedPaths());
+            assertEquals(JFROG_PROJECT, actualServerConfig.getProject());
+            assertEquals(WATCH, actualServerConfig.getWatches());
         }
     }
 
@@ -235,6 +241,8 @@ public class ConfigurationTest extends LightJavaCodeInsightFixtureTestCase {
         assertEquals(CONNECTION_RETRIES, actualServerConfig.getConnectionRetries());
         assertEquals(CONNECTION_TIMEOUT, actualServerConfig.getConnectionTimeout());
         assertEquals(EXCLUDED_PATHS, actualServerConfig.getExcludedPaths());
+        assertEquals(JFROG_PROJECT, actualServerConfig.getProject());
+        assertEquals(WATCH, actualServerConfig.getWatches());
     }
 
     /**


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
