### PR TITLE
Automatically update the Webview checksum

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,7 @@ tasks.register('downloadWebview', Download) {
 tasks.register('getAndUpdateWebviewChecksum') {
     finalizedBy('verifyWebview')
     if (System.getenv("CI") != null) {
+        println 'CI mode is active - Skipping Webview checksum update'
         ext.checksum = webviewChecksum
         return
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,4 @@
+import java.net.http.*
 import java.nio.file.Paths
 
 plugins {
@@ -68,19 +69,29 @@ test {
     }
 }
 
-def webViewVersion = '0.1.16'
-def webviewFileName = 'jfrog-ide-webview-' + webViewVersion + '.tgz'
+def webviewFileName = 'jfrog-ide-webview-' + webviewVersion + '.tgz'
+def webviewUrl = 'https://releases.jfrog.io/artifactory/ide-webview-npm/jfrog-ide-webview/-/' + webviewFileName
 tasks.register('downloadWebview', Download) {
-    src 'https://releases.jfrog.io/artifactory/ide-webview-npm/jfrog-ide-webview/-/' + webviewFileName
+    src webviewUrl
     dest buildDir
     onlyIfModified true
+    finalizedBy('getAndUpdateWebviewChecksum')
+}
+
+tasks.register('getAndUpdateWebviewChecksum') {
     finalizedBy('verifyWebview')
+    if (System.getenv("CI") != null) {
+        ext.checksum = webviewChecksum
+        return
+    }
+    ext.checksum = getWebviewChecksumFromServer(webviewUrl)
+    updateWebviewChecksumInPropertiesFile(ext.checksum)
 }
 
 tasks.register('verifyWebview', Verify) {
     src new File(buildDir, webviewFileName)
-    algorithm 'SHA-512'
-    checksum '72fd49e392320ca25972f6b619330652bcf136383904ed1510d80a9918cbb76ca8fd9a1b053039ec2f74c16ea0e716d05810b4a7f959fb767c1902a8fed7b5bd'
+    algorithm 'SHA-256'
+    checksum getAndUpdateWebviewChecksum.checksum
     finalizedBy('extractWebview')
 }
 
@@ -110,4 +121,29 @@ publishing {
 
 publishPlugin {
     token = System.getenv("JETBRAINS_TOKEN")
+}
+
+/**
+ * Get Webview checksum from releases.jfrog.io
+ * @param webviewUrl - Webview URL
+ * @return the sha256 of the webview
+ */
+static String getWebviewChecksumFromServer(String webviewUrl) {
+    def headRequest = HttpRequest.newBuilder(new URL(webviewUrl).toURI()).method("HEAD", HttpRequest.BodyPublishers.noBody()).build()
+    def checksumResponse = HttpClient.newHttpClient().send(headRequest, HttpResponse.BodyHandlers.ofString())
+    return checksumResponse.headers().firstValue("x-checksum-sha256").get()
+}
+
+/**
+ * Update the Webview checksum in the gradle.properties file
+ * @param checksum - Webview checksum to update
+ */
+static def updateWebviewChecksumInPropertiesFile(String checksum) {
+    def gradleProps = new Properties()
+    File gradlePropertiesFile = new File("gradle.properties");
+    gradlePropertiesFile.withInputStream { gradleProps.load(it) }
+    gradleProps.setProperty("webviewChecksum", checksum)
+    gradlePropertiesFile.withWriter('UTF-8') { fileWriter ->
+        gradleProps.each { key, value -> fileWriter.writeLine "$key=$value" }
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,4 @@
-currentVersion=1.16.x-SNAPSHOT
+webviewVersion=0.1.16
 sandboxVersion=IU-2021.3
+webviewChecksum=115b4ab26a986fed40c31233b2cc1004062472b0df8b450e17242af48b17af2b
+currentVersion=1.16.x-SNAPSHOT


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----

After updating the Webview version, Gradle will update the expected sha256 of the Webview when running locally.