### PR TITLE
Allow creating ignore rules to specific violation 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     implementation group: 'com.jfrog.xray.client', name: 'xray-client-java', version: '0.11.0'
     implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
     implementation group: 'org.jfrog.filespecs', name: 'file-specs-java', version: '1.1.2'
-    implementation group: 'com.jfrog.ide', name: 'ide-plugins-common', version: '1.13.x-20230201.083410-1'
+    implementation group: 'com.jfrog.ide', name: 'ide-plugins-common', version: '1.13.x-20230208.091500-1'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.11'
     implementation group: 'com.google.guava', name: 'guava', version: '30.1.1-jre'
 

--- a/src/main/java/com/jfrog/ide/idea/actions/CreateIgnoreRuleAction.java
+++ b/src/main/java/com/jfrog/ide/idea/actions/CreateIgnoreRuleAction.java
@@ -2,11 +2,20 @@ package com.jfrog.ide.idea.actions;
 
 import com.intellij.icons.AllIcons;
 import com.intellij.ide.BrowserUtil;
+import com.intellij.openapi.options.ShowSettingsUtil;
+import com.intellij.openapi.ui.MessageType;
+import com.intellij.openapi.ui.popup.Balloon;
+import com.intellij.openapi.ui.popup.JBPopupFactory;
+import com.intellij.ui.awt.RelativePoint;
+import com.jfrog.ide.idea.ui.configuration.JFrogGlobalConfiguration;
 
 import javax.swing.*;
 import java.awt.event.ActionEvent;
+import java.awt.event.MouseEvent;
 
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static com.jfrog.ide.idea.ui.LocalComponentsTree.IGNORE_RULE_TOOL_TIP;
+import static javax.swing.event.HyperlinkEvent.EventType.ACTIVATED;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 /**
  * Create Ignore Rule button in the right-click menu of the issues table.
@@ -15,15 +24,34 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
  **/
 public class CreateIgnoreRuleAction extends AbstractAction {
     private final String ignoreRuleUrl;
+    private final MouseEvent mouseEvent;
 
-    public CreateIgnoreRuleAction(String ignoreRuleUrl) {
+    public CreateIgnoreRuleAction(String ignoreRuleUrl, MouseEvent mouseEvent) {
         super("Create Vulnerability Ignore Rule", AllIcons.RunConfigurations.ShowIgnored);
         this.ignoreRuleUrl = ignoreRuleUrl;
-        this.setEnabled(isNotBlank(this.ignoreRuleUrl));
+        this.mouseEvent = mouseEvent;
     }
 
     @Override
     public void actionPerformed(ActionEvent e) {
-        BrowserUtil.browse(ignoreRuleUrl);
+        if (isBlank(this.ignoreRuleUrl)) {
+            Balloon balloon = JBPopupFactory.getInstance().createHtmlTextBalloonBuilder(IGNORE_RULE_TOOL_TIP + "<br><a href=\"configure it here\"> configure it here </a>", MessageType.ERROR,
+                            event -> {
+                                if (!(event.getEventType() == ACTIVATED)) {
+                                    return;
+                                }
+                                ShowSettingsUtil.getInstance().showSettingsDialog(null, JFrogGlobalConfiguration.class, (GlobalConfiguration) -> GlobalConfiguration.selectSettingsTab());
+                            })
+                    .setCloseButtonEnabled(true)
+                    .setHideOnAction(true)
+                    .setHideOnClickOutside(true)
+                    .setHideOnLinkClick(true)
+                    .setHideOnKeyOutside(true)
+                    .setDialogMode(true)
+                    .createBalloon();
+            balloon.show(new RelativePoint(mouseEvent), Balloon.Position.above);
+        } else {
+            BrowserUtil.browse(ignoreRuleUrl);
+        }
     }
 }

--- a/src/main/java/com/jfrog/ide/idea/actions/CreateIgnoreRuleAction.java
+++ b/src/main/java/com/jfrog/ide/idea/actions/CreateIgnoreRuleAction.java
@@ -35,7 +35,7 @@ public class CreateIgnoreRuleAction extends AbstractAction {
     @Override
     public void actionPerformed(ActionEvent e) {
         if (isBlank(this.ignoreRuleUrl)) {
-            Balloon balloon = JBPopupFactory.getInstance().createHtmlTextBalloonBuilder(IGNORE_RULE_TOOL_TIP + "<br><a href=\"Configure it here\"> Configure it here </a>", MessageType.ERROR,
+            Balloon balloon = JBPopupFactory.getInstance().createHtmlTextBalloonBuilder(IGNORE_RULE_TOOL_TIP + "<br><a href=\"Configure it here.\"> Configure it here. </a>", MessageType.ERROR,
                             event -> {
                                 if (event.getEventType() != ACTIVATED) {
                                     return;

--- a/src/main/java/com/jfrog/ide/idea/actions/CreateIgnoreRuleAction.java
+++ b/src/main/java/com/jfrog/ide/idea/actions/CreateIgnoreRuleAction.java
@@ -2,10 +2,11 @@ package com.jfrog.ide.idea.actions;
 
 import com.intellij.icons.AllIcons;
 import com.intellij.ide.BrowserUtil;
-import org.jfrog.build.extractor.scan.Issue;
 
 import javax.swing.*;
 import java.awt.event.ActionEvent;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 /**
  * Create Ignore Rule button in the right-click menu of the issues table.
@@ -13,15 +14,16 @@ import java.awt.event.ActionEvent;
  * @author yahavi
  **/
 public class CreateIgnoreRuleAction extends AbstractAction {
-    private final Issue selectedIssue;
+    private final String ignoreRuleUrl;
 
-    public CreateIgnoreRuleAction(Issue selectedIssue) {
-        super("Create Ignore Rule", AllIcons.RunConfigurations.ShowIgnored);
-        this.selectedIssue = selectedIssue;
+    public CreateIgnoreRuleAction(String ignoreRuleUrl) {
+        super("Create Vulnerability Ignore Rule", AllIcons.RunConfigurations.ShowIgnored);
+        this.ignoreRuleUrl = ignoreRuleUrl;
+        this.setEnabled(isNotBlank(this.ignoreRuleUrl));
     }
 
     @Override
     public void actionPerformed(ActionEvent e) {
-        BrowserUtil.browse(selectedIssue.getIgnoreRuleUrl());
+        BrowserUtil.browse(ignoreRuleUrl);
     }
 }

--- a/src/main/java/com/jfrog/ide/idea/actions/CreateIgnoreRuleAction.java
+++ b/src/main/java/com/jfrog/ide/idea/actions/CreateIgnoreRuleAction.java
@@ -35,9 +35,9 @@ public class CreateIgnoreRuleAction extends AbstractAction {
     @Override
     public void actionPerformed(ActionEvent e) {
         if (isBlank(this.ignoreRuleUrl)) {
-            Balloon balloon = JBPopupFactory.getInstance().createHtmlTextBalloonBuilder(IGNORE_RULE_TOOL_TIP + "<br><a href=\"configure it here\"> configure it here </a>", MessageType.ERROR,
+            Balloon balloon = JBPopupFactory.getInstance().createHtmlTextBalloonBuilder(IGNORE_RULE_TOOL_TIP + "<br><a href=\"Configure it here\"> Configure it here </a>", MessageType.ERROR,
                             event -> {
-                                if (!(event.getEventType() == ACTIVATED)) {
+                                if (event.getEventType() != ACTIVATED) {
                                     return;
                                 }
                                 ShowSettingsUtil.getInstance().showSettingsDialog(null, JFrogGlobalConfiguration.class, (GlobalConfiguration) -> GlobalConfiguration.selectSettingsTab());

--- a/src/main/java/com/jfrog/ide/idea/ui/IssuesTableSelectionListener.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/IssuesTableSelectionListener.java
@@ -2,7 +2,6 @@ package com.jfrog.ide.idea.ui;
 
 import com.intellij.openapi.ui.JBPopupMenu;
 import com.jfrog.ide.idea.actions.CreateIgnoreRuleAction;
-import org.apache.commons.lang3.StringUtils;
 import org.jfrog.build.extractor.scan.DependencyTree;
 import org.jfrog.build.extractor.scan.Issue;
 
@@ -112,12 +111,9 @@ class IssuesTableSelectionListener extends MouseAdapter implements ListSelection
      * @param selectedIssue - The selected issue
      */
     private void doRightClickButtonEvent(MouseEvent mouseEvent, Issue selectedIssue) {
-        if (StringUtils.isBlank(selectedIssue.getIgnoreRuleUrl())) {
-            return;
-        }
         JPopupMenu popupMenu = new JBPopupMenu();
         popupMenu.setFocusable(false);
-        popupMenu.add(new CreateIgnoreRuleAction(selectedIssue));
+        popupMenu.add(new CreateIgnoreRuleAction(selectedIssue.getIgnoreRuleUrl()));
         JBPopupMenu.showByEvent(mouseEvent, popupMenu);
     }
 }

--- a/src/main/java/com/jfrog/ide/idea/ui/IssuesTableSelectionListener.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/IssuesTableSelectionListener.java
@@ -113,7 +113,7 @@ class IssuesTableSelectionListener extends MouseAdapter implements ListSelection
     private void doRightClickButtonEvent(MouseEvent mouseEvent, Issue selectedIssue) {
         JPopupMenu popupMenu = new JBPopupMenu();
         popupMenu.setFocusable(false);
-        popupMenu.add(new CreateIgnoreRuleAction(selectedIssue.getIgnoreRuleUrl()));
+        popupMenu.add(new CreateIgnoreRuleAction(selectedIssue.getIgnoreRuleUrl(), mouseEvent));
         JBPopupMenu.showByEvent(mouseEvent, popupMenu);
     }
 }

--- a/src/main/java/com/jfrog/ide/idea/ui/LocalComponentsTree.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/LocalComponentsTree.java
@@ -102,20 +102,19 @@ public class LocalComponentsTree extends ComponentsTree {
         if (selected instanceof DependencyNode) {
             createNodePopupMenu((DependencyNode) selected);
         } else if (selected instanceof IssueNode) {
-            createIgnoreRuleOption((IssueNode) selected,e);
+            createIgnoreRuleOption((IssueNode) selected, e);
         } else if (selected instanceof ApplicableIssueNode) {
-            createIgnoreRuleOption(((ApplicableIssueNode) selected).getIssue(),e);
-        }
-        else {
+            createIgnoreRuleOption(((ApplicableIssueNode) selected).getIssue(), e);
+        } else {
             // No context menu was created.
             return;
         }
         popupMenu.show(tree, e.getX(), e.getY());
     }
 
-    private void createIgnoreRuleOption(IssueNode selectedIssue,MouseEvent mouseEvent) {
+    private void createIgnoreRuleOption(IssueNode selectedIssue, MouseEvent mouseEvent) {
         popupMenu.removeAll();
-        popupMenu.add( new CreateIgnoreRuleAction(selectedIssue.getIgnoreRuleUrl(), mouseEvent));
+        popupMenu.add(new CreateIgnoreRuleAction(selectedIssue.getIgnoreRuleUrl(), mouseEvent));
         JToolTip toolTip = popupMenu.createToolTip();
         toolTip.setToolTipText(IGNORE_RULE_TOOL_TIP);
         toolTip.setEnabled(true);

--- a/src/main/java/com/jfrog/ide/idea/ui/LocalComponentsTree.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/LocalComponentsTree.java
@@ -5,9 +5,8 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.JBMenuItem;
 import com.intellij.pom.Navigatable;
 import com.intellij.ui.components.JBMenu;
-import com.jfrog.ide.common.tree.BaseTreeNode;
-import com.jfrog.ide.common.tree.DependencyNode;
-import com.jfrog.ide.common.tree.FileTreeNode;
+import com.jfrog.ide.common.tree.*;
+import com.jfrog.ide.idea.actions.CreateIgnoreRuleAction;
 import com.jfrog.ide.idea.navigation.NavigationService;
 import com.jfrog.ide.idea.navigation.NavigationTarget;
 import com.jfrog.ide.idea.ui.menus.ToolbarPopupMenu;
@@ -30,6 +29,7 @@ import java.util.Set;
  */
 public class LocalComponentsTree extends ComponentsTree {
     private static final String SHOW_IN_PROJECT_DESCRIPTOR = "Show direct dependency in project descriptor";
+    private static final String IGNORE_RULE_TOOL_TIP = "Create ignore rule option is only available if JFrog Project or watches are defined";
 
     List<FileTreeNode> fileNodes = new ArrayList<>();
 
@@ -98,12 +98,27 @@ public class LocalComponentsTree extends ComponentsTree {
         if (selectedPath == null) {
             return;
         }
-        if (selectedPath.getLastPathComponent() instanceof DependencyNode) {
-            createNodePopupMenu((DependencyNode) selectedPath.getLastPathComponent());
-            popupMenu.show(tree, e.getX(), e.getY());
+        var selected = selectedPath.getLastPathComponent();
+        if (selected instanceof DependencyNode) {
+            createNodePopupMenu((DependencyNode) selected);
         }
+        if (selected instanceof IssueNode) {
+            createIgnoreRuleOption((IssueNode) selected);
+        }
+        if (selected instanceof ApplicableIssueNode) {
+            createIgnoreRuleOption(((ApplicableIssueNode) selected).getIssue());
+        }
+        popupMenu.show(tree, e.getX(), e.getY());
     }
 
+    private void createIgnoreRuleOption(IssueNode selectedIssue) {
+        popupMenu.removeAll();
+        popupMenu.setFocusable(false);
+        popupMenu.add(new CreateIgnoreRuleAction(selectedIssue.getIgnoreRuleUrl()));
+        JToolTip toolTip = popupMenu.createToolTip();
+        toolTip.setToolTipText(IGNORE_RULE_TOOL_TIP);
+        toolTip.setEnabled(true);
+    }
 
     private void createNodePopupMenu(DependencyNode selectedNode) {
         popupMenu.removeAll();

--- a/src/main/java/com/jfrog/ide/idea/ui/LocalComponentsTree.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/LocalComponentsTree.java
@@ -29,7 +29,7 @@ import java.util.Set;
  */
 public class LocalComponentsTree extends ComponentsTree {
     private static final String SHOW_IN_PROJECT_DESCRIPTOR = "Show direct dependency in project descriptor";
-    private static final String IGNORE_RULE_TOOL_TIP = "Create ignore rule option is only available if JFrog Project or watches are defined";
+    public static final String IGNORE_RULE_TOOL_TIP = "Creating Ignore Rules is only available when a JFrog Project or Watch is defined.";
 
     List<FileTreeNode> fileNodes = new ArrayList<>();
 
@@ -101,20 +101,21 @@ public class LocalComponentsTree extends ComponentsTree {
         var selected = selectedPath.getLastPathComponent();
         if (selected instanceof DependencyNode) {
             createNodePopupMenu((DependencyNode) selected);
+        } else if (selected instanceof IssueNode) {
+            createIgnoreRuleOption((IssueNode) selected,e);
+        } else if (selected instanceof ApplicableIssueNode) {
+            createIgnoreRuleOption(((ApplicableIssueNode) selected).getIssue(),e);
         }
-        if (selected instanceof IssueNode) {
-            createIgnoreRuleOption((IssueNode) selected);
-        }
-        if (selected instanceof ApplicableIssueNode) {
-            createIgnoreRuleOption(((ApplicableIssueNode) selected).getIssue());
+        else {
+            // No context menu was created.
+            return;
         }
         popupMenu.show(tree, e.getX(), e.getY());
     }
 
-    private void createIgnoreRuleOption(IssueNode selectedIssue) {
+    private void createIgnoreRuleOption(IssueNode selectedIssue,MouseEvent mouseEvent) {
         popupMenu.removeAll();
-        popupMenu.setFocusable(false);
-        popupMenu.add(new CreateIgnoreRuleAction(selectedIssue.getIgnoreRuleUrl()));
+        popupMenu.add( new CreateIgnoreRuleAction(selectedIssue.getIgnoreRuleUrl(), mouseEvent));
         JToolTip toolTip = popupMenu.createToolTip();
         toolTip.setToolTipText(IGNORE_RULE_TOOL_TIP);
         toolTip.setEnabled(true);

--- a/src/main/java/com/jfrog/ide/idea/ui/configuration/JFrogGlobalConfiguration.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/configuration/JFrogGlobalConfiguration.java
@@ -91,7 +91,10 @@ public class JFrogGlobalConfiguration implements Configurable, Configurable.NoSc
     private JRadioButton accordingToWatchesRadioButton;
     private JButton defaultValuesButton;
 
+    private int selectedTabIndex;
+
     public JFrogGlobalConfiguration() {
+        createComponent();
         initUrls();
         initTestConnection();
         initConnectionDetailsFromEnv();
@@ -108,7 +111,12 @@ public class JFrogGlobalConfiguration implements Configurable, Configurable.NoSc
         tabbedPane.add("Connection Details", connectionDetails);
         tabbedPane.add("Settings", settings);
         tabbedPane.add("Advanced", advanced);
+        tabbedPane.setSelectedIndex(selectedTabIndex);
         return tabbedPane;
+    }
+
+    public void selectSettingsTab() {
+        selectedTabIndex = 1;
     }
 
     private void initUrls() {


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
Added the option to create ignore rule in the right-click context menu.
Fixes https://github.com/jfrog/jfrog-idea-plugin/issues/238
Depends on https://github.com/jfrog/ide-plugins-common/pull/103

After right-click:

![Screenshot 2023-01-23 at 17 13 52](https://user-images.githubusercontent.com/24526180/214075706-eda48635-22ac-4df7-a744-f8fe818b7303.png)

When no project/watch was configured so the ignore rule cannot be created:

![2](https://user-images.githubusercontent.com/24526180/215731911-f70b7f89-dfc6-4db0-a53f-4cbaf82bbd2f.png)
