### PR TITLE
Add Inactive Jfrog platform handling (free-tier)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     implementation group: 'com.jfrog.xray.client', name: 'xray-client-java', version: '0.13.x-20230219.134632-1'
     implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
     implementation group: 'org.jfrog.filespecs', name: 'file-specs-java', version: '1.1.2'
-    implementation group: 'com.jfrog.ide', name: 'ide-plugins-common', version: '1.13.x-20230214.072934-1'
+    implementation group: 'com.jfrog.ide', name: 'ide-plugins-common', version: '1.13.x-20230221.095443-1'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.11'
     implementation group: 'com.google.guava', name: 'guava', version: '30.1.1-jre'
 

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     implementation group: 'org.jfrog.buildinfo', name: 'build-info-client', version: buildInfoVersion
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.14.0'
     implementation group: 'org.jfrog.buildinfo', name: 'build-info-api', version: buildInfoVersion
-    implementation group: 'com.jfrog.xray.client', name: 'xray-client-java', version: '0.11.0'
+    implementation group: 'com.jfrog.xray.client', name: 'xray-client-java', version: '0.13.x-20230219.134632-1'
     implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
     implementation group: 'org.jfrog.filespecs', name: 'file-specs-java', version: '1.1.2'
     implementation group: 'com.jfrog.ide', name: 'ide-plugins-common', version: '1.13.x-20230214.072934-1'

--- a/src/main/java/com/jfrog/ide/idea/ui/configuration/JFrogGlobalConfiguration.form
+++ b/src/main/java/com/jfrog/ide/idea/ui/configuration/JFrogGlobalConfiguration.form
@@ -276,6 +276,14 @@
               <text value="Authentication method"/>
             </properties>
           </component>
+          <component id="5d973" class="com.intellij.ui.HyperlinkLabel" binding="inActiveEnv">
+            <constraints>
+              <grid row="14" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="9" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value=""/>
+            </properties>
+          </component>
         </children>
       </grid>
       <grid id="eca9a" binding="settings" layout-manager="GridLayoutManager" row-count="16" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">

--- a/src/main/java/com/jfrog/ide/idea/ui/configuration/JFrogGlobalConfiguration.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/configuration/JFrogGlobalConfiguration.java
@@ -17,6 +17,7 @@ import com.jfrog.ide.idea.log.Logger;
 import com.jfrog.ide.idea.ui.components.ConnectionResultsGesture;
 import com.jfrog.xray.client.Xray;
 import com.jfrog.xray.client.impl.XrayClientBuilder;
+import com.jfrog.xray.client.impl.util.JFrogInactiveEnvironmentException;
 import com.jfrog.xray.client.services.system.Version;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -90,6 +91,7 @@ public class JFrogGlobalConfiguration implements Configurable, Configurable.NoSc
     private JRadioButton accordingToProjectRadioButton;
     private JRadioButton accordingToWatchesRadioButton;
     private JButton defaultValuesButton;
+    private HyperlinkLabel inActiveEnv;
 
     private int selectedTabIndex;
 
@@ -202,6 +204,9 @@ public class JFrogGlobalConfiguration implements Configurable, Configurable.NoSc
             connectionResultsGesture.setSuccess();
             return Results.success(xrayVersion);
         } catch (IOException exception) {
+            if (exception instanceof JFrogInactiveEnvironmentException) {
+                initHyperlink(inActiveEnv, "JFrog Platform is not active.\nYou can activate it<hyperlink>here</hyperlink>.", ((JFrogInactiveEnvironmentException) exception).getRedirectUrl());
+            }
             connectionResultsGesture.setFailure(ExceptionUtils.getRootCauseMessage(exception));
             return "Could not connect to JFrog Xray.";
         }


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
Detect and suggest a solution for an inactive JFrog platform (free-tier).

![Screenshot 2023-02-06 at 11 25 03](https://user-images.githubusercontent.com/24526180/216936088-de776311-132e-4c45-be19-cae6dc252d39.png)

Fixes https://github.com/jfrog/jfrog-idea-plugin/issues/228
Depends on https://github.com/jfrog/xray-client-java/pull/42, https://github.com/jfrog/build-info/pull/698
