### PR TITLE
Fix Default Excluded Paths

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/configuration/ServerConfigImpl.java
+++ b/src/main/java/com/jfrog/ide/idea/configuration/ServerConfigImpl.java
@@ -47,6 +47,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.Objects;
 
+import static com.jfrog.ide.idea.ui.configuration.ConfigVerificationUtils.DEFAULT_EXCLUSIONS;
 import static com.jfrog.ide.idea.ui.configuration.Utils.*;
 import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
 import static org.apache.commons.lang3.StringUtils.*;
@@ -210,7 +211,7 @@ public class ServerConfigImpl implements ServerConfig {
     }
 
     public String getExcludedPaths() {
-        return this.excludedPaths;
+        return defaultIfNull(this.excludedPaths, DEFAULT_EXCLUSIONS);
     }
 
     @Override

--- a/src/main/java/com/jfrog/ide/idea/scan/SourceCodeScannerManager.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/SourceCodeScannerManager.java
@@ -85,13 +85,15 @@ public class SourceCodeScannerManager {
     private List<String> getSkippedFoldersPatterns() {
         String excludePattern = GlobalSettings.getInstance().getServerConfig().getExcludedPaths();
         List<String> skippedFoldersPatterns = new ArrayList<>();
-        Matcher matcher = EXCLUSIONS_REGEX_PATTERN.matcher(excludePattern);
-        if (!matcher.find()) {
-            return List.of(excludePattern);
-        }
-        String[] dirsNames = matcher.group(1).split(",");
-        for (String dirName : dirsNames) {
-            skippedFoldersPatterns.add(EXCLUSIONS_PREFIX + dirName.strip() + EXCLUSIONS_SUFFIX);
+        if (StringUtils.isNotBlank(excludePattern)) {
+            Matcher matcher = EXCLUSIONS_REGEX_PATTERN.matcher(excludePattern);
+            if (!matcher.find()) {
+                return List.of(excludePattern);
+            }
+            String[] dirsNames = matcher.group(1).split(",");
+            for (String dirName : dirsNames) {
+                skippedFoldersPatterns.add(EXCLUSIONS_PREFIX + dirName.strip() + EXCLUSIONS_SUFFIX);
+            }
         }
         return skippedFoldersPatterns;
     }


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
This PR fixes 2 bugs related to the excluded paths config param:

- Set the field with default excluded paths by default.
- Fix the conversion of the excluded paths param, so the applicability scanners will work if an empty pattern is configured.