### PR TITLE
Add support for Downloading  the AnalyzerManager

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     implementation group: 'org.jfrog.buildinfo', name: 'build-info-client', version: buildInfoVersion
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.14.0'
     implementation group: 'org.jfrog.buildinfo', name: 'build-info-api', version: buildInfoVersion
-    implementation group: 'net.lingala.zip4j', name: 'zip4j', version: '2.11.3'
+    implementation group: 'net.lingala.zip4j', name: 'zip4j', version: '2.11.4'
     implementation group: 'com.jfrog.xray.client', name: 'xray-client-java', version: '0.13.x-20230219.172211-1'
     implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
     implementation group: 'org.jfrog.filespecs', name: 'file-specs-java', version: '1.1.2'
@@ -59,9 +59,7 @@ dependencies {
     testImplementation group: 'org.mockito', name: 'mockito-inline', version: '4.2.0'
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '4.2.0'
 
-
 }
-
 
 test {
     scanForTestClasses false

--- a/build.gradle
+++ b/build.gradle
@@ -49,16 +49,19 @@ dependencies {
     implementation group: 'org.jfrog.buildinfo', name: 'build-info-client', version: buildInfoVersion
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.14.0'
     implementation group: 'org.jfrog.buildinfo', name: 'build-info-api', version: buildInfoVersion
-    implementation group: 'com.jfrog.xray.client', name: 'xray-client-java', version: '0.13.x-20230219.134632-1'
+    implementation group: 'net.lingala.zip4j', name: 'zip4j', version: '2.11.3'
+    implementation group: 'com.jfrog.xray.client', name: 'xray-client-java', version: '0.13.x-20230219.172211-1'
     implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
     implementation group: 'org.jfrog.filespecs', name: 'file-specs-java', version: '1.1.2'
     implementation group: 'com.jfrog.ide', name: 'ide-plugins-common', version: '1.13.x-20230221.095443-1'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.11'
     implementation group: 'com.google.guava', name: 'guava', version: '30.1.1-jre'
-
     testImplementation group: 'org.mockito', name: 'mockito-inline', version: '4.2.0'
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '4.2.0'
+
+
 }
+
 
 test {
     scanForTestClasses false

--- a/src/main/java/com/jfrog/ide/idea/scan/ApplicabilityScannerExecutor.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ApplicabilityScannerExecutor.java
@@ -6,7 +6,6 @@ import com.jfrog.ide.idea.scan.data.Rule;
 import com.jfrog.ide.idea.scan.data.Run;
 import com.jfrog.ide.idea.scan.data.ScanConfig;
 import com.jfrog.xray.client.services.entitlements.Feature;
-import org.apache.commons.lang3.SystemUtils;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -21,12 +20,13 @@ import java.util.stream.Stream;
  */
 public class ApplicabilityScannerExecutor extends ScanBinaryExecutor {
     private static final String SCAN_TYPE = "analyze-applicability";
-    private static final String SCANNER_BINARY_NAME = SystemUtils.IS_OS_WINDOWS ? "analyzerManager.exe" : "analyzerManager";
+    private static final String SCANNER_BINARY_NAME = "analyzerManager";
     private static final List<String> SCANNER_ARGS = List.of("ca");
     private static final String BINARY_DOWNLOAD_URL = "xsc-gen-exe-analyzer-manager-local/v1/[RELEASE]";
+    private static final String DOWNLOAD_SCANNER_NAME = "analyzerManager.zip";
 
     public ApplicabilityScannerExecutor() {
-        super(SCAN_TYPE, SCANNER_BINARY_NAME);
+        super(SCAN_TYPE, SCANNER_BINARY_NAME, DOWNLOAD_SCANNER_NAME);
         supportedLanguages = List.of("python", "js");
     }
 
@@ -36,7 +36,7 @@ public class ApplicabilityScannerExecutor extends ScanBinaryExecutor {
 
     @Override
     String getBinaryDownloadURL() {
-        return String.format("%s/%s/%s", BINARY_DOWNLOAD_URL, getOsDistribution(), SCANNER_BINARY_NAME);
+        return String.format("%s/%s/%s", BINARY_DOWNLOAD_URL, getOsDistribution(), DOWNLOAD_SCANNER_NAME);
     }
 
     @Override

--- a/src/main/java/com/jfrog/ide/idea/scan/ApplicabilityScannerExecutor.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ApplicabilityScannerExecutor.java
@@ -1,5 +1,6 @@
 package com.jfrog.ide.idea.scan;
 
+import com.jfrog.ide.common.configuration.ServerConfig;
 import com.jfrog.ide.idea.inspections.JFrogSecurityWarning;
 import com.jfrog.ide.idea.scan.data.Output;
 import com.jfrog.ide.idea.scan.data.Rule;
@@ -25,8 +26,8 @@ public class ApplicabilityScannerExecutor extends ScanBinaryExecutor {
     private static final String BINARY_DOWNLOAD_URL = "xsc-gen-exe-analyzer-manager-local/v1/[RELEASE]";
     private static final String DOWNLOAD_SCANNER_NAME = "analyzerManager.zip";
 
-    public ApplicabilityScannerExecutor(Log log) {
-        super(SCAN_TYPE, SCANNER_BINARY_NAME, DOWNLOAD_SCANNER_NAME, log);
+    public ApplicabilityScannerExecutor(Log log, ServerConfig serverConfig) {
+        super(SCAN_TYPE, SCANNER_BINARY_NAME, DOWNLOAD_SCANNER_NAME, log, serverConfig);
         supportedLanguages = List.of("python", "js");
     }
 

--- a/src/main/java/com/jfrog/ide/idea/scan/ApplicabilityScannerExecutor.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ApplicabilityScannerExecutor.java
@@ -6,6 +6,7 @@ import com.jfrog.ide.idea.scan.data.Rule;
 import com.jfrog.ide.idea.scan.data.Run;
 import com.jfrog.ide.idea.scan.data.ScanConfig;
 import com.jfrog.xray.client.services.entitlements.Feature;
+import org.jfrog.build.api.util.Log;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -13,7 +14,6 @@ import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Stream;
 
 /**
  * @author Tal Arian
@@ -25,8 +25,8 @@ public class ApplicabilityScannerExecutor extends ScanBinaryExecutor {
     private static final String BINARY_DOWNLOAD_URL = "xsc-gen-exe-analyzer-manager-local/v1/[RELEASE]";
     private static final String DOWNLOAD_SCANNER_NAME = "analyzerManager.zip";
 
-    public ApplicabilityScannerExecutor() {
-        super(SCAN_TYPE, SCANNER_BINARY_NAME, DOWNLOAD_SCANNER_NAME);
+    public ApplicabilityScannerExecutor(Log log) {
+        super(SCAN_TYPE, SCANNER_BINARY_NAME, DOWNLOAD_SCANNER_NAME, log);
         supportedLanguages = List.of("python", "js");
     }
 
@@ -58,9 +58,6 @@ public class ApplicabilityScannerExecutor extends ScanBinaryExecutor {
                 String ScannerSearchTarget = scanners.stream().filter(scanner -> scanner.getId().equals(warning.getName())).findFirst().map(scanner -> scanner.getFullDescription().getText()).orElse("");
                 warning.setScannerSearchTarget(ScannerSearchTarget);
             }
-            // Adds the not applicable CVEs data
-            Stream<String> knownCves = scanners.stream().map(Rule::getId);
-            knownCves.filter(cve -> !applicabilityCves.contains(cve)).forEach(cve -> results.add(new JFrogSecurityWarning(cve, false)));
         }
         return results;
     }

--- a/src/main/java/com/jfrog/ide/idea/scan/ApplicabilityScannerExecutor.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ApplicabilityScannerExecutor.java
@@ -10,7 +10,6 @@ import com.jfrog.xray.client.services.entitlements.Feature;
 import org.jfrog.build.api.util.Log;
 
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
@@ -31,7 +30,7 @@ public class ApplicabilityScannerExecutor extends ScanBinaryExecutor {
         supportedLanguages = List.of("python", "js");
     }
 
-    public List<JFrogSecurityWarning> execute(ScanConfig.Builder inputFileBuilder) throws IOException, InterruptedException, URISyntaxException {
+    public List<JFrogSecurityWarning> execute(ScanConfig.Builder inputFileBuilder) throws IOException, InterruptedException {
         return super.execute(inputFileBuilder, SCANNER_ARGS);
     }
 

--- a/src/main/java/com/jfrog/ide/idea/scan/ApplicabilityScannerExecutor.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ApplicabilityScannerExecutor.java
@@ -5,8 +5,11 @@ import com.jfrog.ide.idea.scan.data.Output;
 import com.jfrog.ide.idea.scan.data.Rule;
 import com.jfrog.ide.idea.scan.data.Run;
 import com.jfrog.ide.idea.scan.data.ScanConfig;
+import com.jfrog.xray.client.services.entitlements.Feature;
+import org.apache.commons.lang3.SystemUtils;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
@@ -18,16 +21,27 @@ import java.util.stream.Stream;
  */
 public class ApplicabilityScannerExecutor extends ScanBinaryExecutor {
     private static final String SCAN_TYPE = "analyze-applicability";
-    private static final String SCANNER_BINARY_NAME = "analyzerManager";
+    private static final String SCANNER_BINARY_NAME = SystemUtils.IS_OS_WINDOWS ? "analyzerManager.exe" : "analyzerManager";
     private static final List<String> SCANNER_ARGS = List.of("ca");
+    private static final String BINARY_DOWNLOAD_URL = "xsc-gen-exe-analyzer-manager-local/v1/[RELEASE]";
 
     public ApplicabilityScannerExecutor() {
         super(SCAN_TYPE, SCANNER_BINARY_NAME);
         supportedLanguages = List.of("python", "js");
     }
 
-    public List<JFrogSecurityWarning> execute(ScanConfig.Builder inputFileBuilder) throws IOException, InterruptedException {
+    public List<JFrogSecurityWarning> execute(ScanConfig.Builder inputFileBuilder) throws IOException, InterruptedException, URISyntaxException {
         return super.execute(inputFileBuilder, SCANNER_ARGS);
+    }
+
+    @Override
+    String getBinaryDownloadURL() {
+        return String.format("%s/%s/%s", BINARY_DOWNLOAD_URL, getOsDistribution(), SCANNER_BINARY_NAME);
+    }
+
+    @Override
+    Feature getScannerFeatureName() {
+        return Feature.ContextualAnalysis;
     }
 
     @Override

--- a/src/main/java/com/jfrog/ide/idea/scan/Eos.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/Eos.java
@@ -1,10 +1,10 @@
 package com.jfrog.ide.idea.scan;
 
+import com.jfrog.ide.common.configuration.ServerConfig;
 import com.jfrog.ide.idea.inspections.JFrogSecurityWarning;
 import com.jfrog.ide.idea.scan.data.ScanConfig;
 import com.jfrog.xray.client.services.entitlements.Feature;
 import org.jfrog.build.api.util.Log;
-
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -20,8 +20,8 @@ public class Eos extends ScanBinaryExecutor {
     private static final String SCANNER_BINARY_NAME = "Eos";
     private static final List<String> SCANNER_ARGS = List.of("analyze", "config");
 
-    public Eos(Log log) {
-        super(SCAN_TYPE, SCANNER_BINARY_NAME, DOWNLOAD_SCANNER_NAME, log);
+    public Eos(Log log, ServerConfig server) {
+        super(SCAN_TYPE, SCANNER_BINARY_NAME, DOWNLOAD_SCANNER_NAME, log, server);
         supportedLanguages = List.of("python");
     }
 

--- a/src/main/java/com/jfrog/ide/idea/scan/Eos.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/Eos.java
@@ -2,8 +2,10 @@ package com.jfrog.ide.idea.scan;
 
 import com.jfrog.ide.idea.inspections.JFrogSecurityWarning;
 import com.jfrog.ide.idea.scan.data.ScanConfig;
+import com.jfrog.xray.client.services.entitlements.Feature;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.List;
 
 /**
@@ -19,8 +21,18 @@ public class Eos extends ScanBinaryExecutor {
         supportedLanguages = List.of("python");
     }
 
-    public List<JFrogSecurityWarning> execute(ScanConfig.Builder inputFileBuilder) throws IOException, InterruptedException {
+    public List<JFrogSecurityWarning> execute(ScanConfig.Builder inputFileBuilder) throws IOException, InterruptedException, URISyntaxException {
         return super.execute(inputFileBuilder, SCANNER_ARGS);
+    }
+
+    @Override
+    String getBinaryDownloadURL() {
+        return null;
+    }
+
+    @Override
+    Feature getScannerFeatureName() {
+        return null;
     }
 
 }

--- a/src/main/java/com/jfrog/ide/idea/scan/Eos.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/Eos.java
@@ -13,11 +13,13 @@ import java.util.List;
  */
 public class Eos extends ScanBinaryExecutor {
     private static final String SCAN_TYPE = "analyze-codebase";
+    private static final String DOWNLOAD_SCANNER_NAME = "analyzerManager.zip";
+
     private static final String SCANNER_BINARY_NAME = "Eos";
     private static final List<String> SCANNER_ARGS = List.of("analyze", "config");
 
     public Eos() {
-        super(SCAN_TYPE, SCANNER_BINARY_NAME);
+        super(SCAN_TYPE, SCANNER_BINARY_NAME, DOWNLOAD_SCANNER_NAME);
         supportedLanguages = List.of("python");
     }
 

--- a/src/main/java/com/jfrog/ide/idea/scan/Eos.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/Eos.java
@@ -3,6 +3,8 @@ package com.jfrog.ide.idea.scan;
 import com.jfrog.ide.idea.inspections.JFrogSecurityWarning;
 import com.jfrog.ide.idea.scan.data.ScanConfig;
 import com.jfrog.xray.client.services.entitlements.Feature;
+import org.jfrog.build.api.util.Log;
+
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -18,8 +20,8 @@ public class Eos extends ScanBinaryExecutor {
     private static final String SCANNER_BINARY_NAME = "Eos";
     private static final List<String> SCANNER_ARGS = List.of("analyze", "config");
 
-    public Eos() {
-        super(SCAN_TYPE, SCANNER_BINARY_NAME, DOWNLOAD_SCANNER_NAME);
+    public Eos(Log log) {
+        super(SCAN_TYPE, SCANNER_BINARY_NAME, DOWNLOAD_SCANNER_NAME, log);
         supportedLanguages = List.of("python");
     }
 

--- a/src/main/java/com/jfrog/ide/idea/scan/ScanBinaryExecutor.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ScanBinaryExecutor.java
@@ -71,12 +71,12 @@ public abstract class ScanBinaryExecutor {
     private final ArtifactoryManagerBuilder artifactoryManagerBuilder;
 
 
-    ScanBinaryExecutor(String scanType, String binaryName, String archiveName) {
+    ScanBinaryExecutor(String scanType, String binaryName, String archiveName, Log log) {
         this.scanType = scanType;
+        this.log = log;
         String executable = SystemUtils.IS_OS_WINDOWS ? binaryName + ".exe" : binaryName;
         binaryTargetPath = BINARIES_DIR.resolve(binaryName).resolve(executable);
         archiveTargetPath = BINARIES_DIR.resolve(archiveName);
-        log = Logger.getInstance();
         ServerConfig server = GlobalSettings.getInstance().getServerConfig();
         artifactoryManagerBuilder = createAnonymousAccessArtifactoryManagerBuilder(JFROG_RELEASES, server.getProxyConfForTargetUrl(JFROG_RELEASES), log);
         try {

--- a/src/main/java/com/jfrog/ide/idea/scan/ScanBinaryExecutor.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ScanBinaryExecutor.java
@@ -71,13 +71,12 @@ public abstract class ScanBinaryExecutor {
     private final ArtifactoryManagerBuilder artifactoryManagerBuilder;
 
 
-    ScanBinaryExecutor(String scanType, String binaryName, String archiveName, Log log) {
+    ScanBinaryExecutor(String scanType, String binaryName, String archiveName, Log log, ServerConfig server) {
         this.scanType = scanType;
         this.log = log;
         String executable = SystemUtils.IS_OS_WINDOWS ? binaryName + ".exe" : binaryName;
         binaryTargetPath = BINARIES_DIR.resolve(binaryName).resolve(executable);
         archiveTargetPath = BINARIES_DIR.resolve(archiveName);
-        ServerConfig server = GlobalSettings.getInstance().getServerConfig();
         artifactoryManagerBuilder = createAnonymousAccessArtifactoryManagerBuilder(JFROG_RELEASES, server.getProxyConfForTargetUrl(JFROG_RELEASES), log);
         try {
             osDistribution = getOSAndArc();

--- a/src/main/java/com/jfrog/ide/idea/scan/ScanBinaryExecutor.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ScanBinaryExecutor.java
@@ -2,6 +2,7 @@ package com.jfrog.ide.idea.scan;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.intellij.util.EnvironmentUtil;
+import com.jfrog.ide.common.configuration.ServerConfig;
 import com.jfrog.ide.idea.configuration.GlobalSettings;
 import com.jfrog.ide.idea.configuration.ServerConfigImpl;
 import com.jfrog.ide.idea.inspections.JFrogSecurityWarning;
@@ -9,21 +10,37 @@ import com.jfrog.ide.idea.log.Logger;
 import com.jfrog.ide.idea.scan.data.Output;
 import com.jfrog.ide.idea.scan.data.ScanConfig;
 import com.jfrog.ide.idea.scan.data.ScansConfig;
+import com.jfrog.xray.client.Xray;
+import com.jfrog.xray.client.services.entitlements.Feature;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
+import org.jfrog.build.api.util.Log;
 import org.jfrog.build.client.ProxyConfiguration;
+import org.jfrog.build.extractor.clientConfiguration.ArtifactoryManagerBuilder;
+import org.jfrog.build.extractor.clientConfiguration.client.artifactory.ArtifactoryManager;
 import org.jfrog.build.extractor.executor.CommandExecutor;
 import org.jfrog.build.extractor.executor.CommandResults;
 
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.*;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
+import static com.jfrog.ide.common.utils.ArtifactoryConnectionUtils.createAnonymousAccessArtifactoryManagerBuilder;
 import static com.jfrog.ide.common.utils.Utils.createMapper;
 import static com.jfrog.ide.common.utils.Utils.createYAMLMapper;
+import static com.jfrog.ide.common.utils.XrayConnectionUtils.createXrayClientBuilder;
 import static com.jfrog.ide.idea.utils.Utils.HOME_PATH;
+import static com.jfrog.ide.idea.utils.Utils.getFileChecksumFromServer;
 
 /**
  * @author Tal Arian
@@ -31,9 +48,13 @@ import static com.jfrog.ide.idea.utils.Utils.HOME_PATH;
 public abstract class ScanBinaryExecutor {
     final String scanType;
     protected List<String> supportedLanguages;
-    private final boolean shouldExecute;
-    private final String binaryPath;
     private static final Path BINARIES_DIR = HOME_PATH.resolve("dependencies").resolve("jfrog-security");
+    private static Path BINARY_TARGET_PATH;
+    private static final String MINIMAL_XRAY_VERSION_SUPPORTED_FOR_ENTITLEMENT = "3.66.0";
+    private static final int UPDATE_INTERVAL = 1;
+    private static LocalDateTime nextUpdateCheck;
+    private Log log;
+    private boolean notSupportedOS;
     private static final String ENV_PLATFORM = "JF_PLATFORM_URL";
     private static final String ENV_USER = "JF_USER";
     private static final String ENV_PASSWORD = "JF_PASS";
@@ -41,50 +62,42 @@ public abstract class ScanBinaryExecutor {
     private static final String ENV_HTTP_PROXY = "HTTP_PROXY";
     private static final String ENV_HTTPS_PROXY = "HTTPS_PROXY";
     private static final int USER_NOT_ENTITLED = 31;
+    private static final String JFROG_RELEASES = "https://releases.jfrog.io/artifactory/";
+    private static String osDistribution;
+    private final ArtifactoryManagerBuilder artifactoryManagerBuilder;
 
 
     ScanBinaryExecutor(String scanType, String binaryName) {
         this.scanType = scanType;
-        if (SystemUtils.IS_OS_WINDOWS) {
-            binaryName += ".exe";
+        BINARY_TARGET_PATH = BINARIES_DIR.resolve(binaryName);
+        commandExecutor = new CommandExecutor(BINARY_TARGET_PATH.toString(), creatEnvWithCredentials());
+        log = Logger.getInstance();
+        ServerConfig server = GlobalSettings.getInstance().getServerConfig();
+        artifactoryManagerBuilder = createAnonymousAccessArtifactoryManagerBuilder(JFROG_RELEASES, server.getProxyConfForTargetUrl(JFROG_RELEASES), log);
+        try {
+            osDistribution = getOSAndArc();
+        } catch (IOException e) {
+            log.info(e.getMessage());
+            notSupportedOS = true;
         }
-        Path binaryPath = BINARIES_DIR.resolve(binaryName);
-        shouldExecute = Files.exists(binaryPath);
-        this.binaryPath = binaryPath.toString();
     }
 
-    private Map<String, String> creatEnvWithCredentials() {
-        Map<String, String> env = new HashMap<>(EnvironmentUtil.getEnvironmentMap());
-        ServerConfigImpl serverConfig = GlobalSettings.getInstance().getServerConfig();
-        if (serverConfig.isXrayConfigured()) {
-            env.put(ENV_PLATFORM, serverConfig.getUrl());
-            if (StringUtils.isNotEmpty(serverConfig.getAccessToken())) {
-                env.put(ENV_ACCESS_TOKEN, serverConfig.getAccessToken());
-            } else {
-                env.put(ENV_USER, serverConfig.getUsername());
-                env.put(ENV_PASSWORD, serverConfig.getPassword());
-            }
-
-            ProxyConfiguration proxyConfiguration = serverConfig.getProxyConfForTargetUrl(serverConfig.getUrl());
-            if (proxyConfiguration != null) {
-                String proxyUrl = proxyConfiguration.host + ":" + proxyConfiguration.port;
-                if (StringUtils.isNoneBlank(proxyConfiguration.username, proxyConfiguration.password)) {
-                    proxyUrl = proxyConfiguration.username + ":" + proxyConfiguration.password + "@" + proxyUrl;
-                }
-                env.put(ENV_HTTP_PROXY, "http://" + proxyUrl);
-                env.put(ENV_HTTPS_PROXY, "https://" + proxyUrl);
-            }
-        }
-        return env;
+    public static String getOsDistribution() {
+        return osDistribution;
     }
 
-    abstract List<JFrogSecurityWarning> execute(ScanConfig.Builder inputFileBuilder) throws IOException, InterruptedException;
+    abstract List<JFrogSecurityWarning> execute(ScanConfig.Builder inputFileBuilder) throws IOException, InterruptedException, URISyntaxException;
 
-    protected List<JFrogSecurityWarning> execute(ScanConfig.Builder inputFileBuilder, List<String> args) throws IOException, InterruptedException {
-        if (!shouldExecute) {
+    abstract String getBinaryDownloadURL();
+
+    abstract Feature getScannerFeatureName();
+
+    protected List<JFrogSecurityWarning> execute(ScanConfig.Builder inputFileBuilder, List<String> args) throws IOException, InterruptedException, URISyntaxException {
+        if (notSupportedOS || !shouldExecute()) {
             return List.of();
         }
-        CommandExecutor commandExecutor = new CommandExecutor(binaryPath, creatEnvWithCredentials());
+        CommandExecutor commandExecutor = new CommandExecutor(BINARY_TARGET_PATH.toString(), creatEnvWithCredentials());
+        updateBinaryIfNeeded();
         Path outputTempDir = null;
         Path inputFile = null;
         try {
@@ -117,6 +130,41 @@ public abstract class ScanBinaryExecutor {
         }
     }
 
+    private void updateBinaryIfNeeded() throws IOException, URISyntaxException, InterruptedException {
+        if (!Files.exists(BINARY_TARGET_PATH)) {
+            downloadBinary();
+            return;
+        }
+        if (nextUpdateCheck == null || LocalDateTime.now().isAfter(nextUpdateCheck)) {
+            var currentTime = LocalDateTime.now();
+            nextUpdateCheck = LocalDateTime.of(currentTime.getYear(), currentTime.getMonth(), currentTime.getDayOfMonth() + UPDATE_INTERVAL, currentTime.getHour(), currentTime.getMinute(), currentTime.getSecond());
+            // Check for new version of the binary
+            try (FileInputStream binaryFile = new FileInputStream(BINARY_TARGET_PATH.toFile())) {
+                String latestBinaryChecksum = getFileChecksumFromServer(JFROG_RELEASES + getBinaryDownloadURL());
+                String currentBinaryCheckSum = DigestUtils.sha256Hex(binaryFile).toString();
+                if (!latestBinaryChecksum.equals(currentBinaryCheckSum)) {
+                    downloadBinary();
+                }
+            }
+        }
+    }
+
+
+    protected boolean shouldExecute() {
+        ServerConfig server = GlobalSettings.getInstance().getServerConfig();
+        try (Xray xrayClient = createXrayClientBuilder(server, log).build()) {
+            try {
+                if (xrayClient.system().version().isAtLeast(MINIMAL_XRAY_VERSION_SUPPORTED_FOR_ENTITLEMENT)) {
+                    return false;
+                }
+            } catch (IOException e) {
+                log.error("Couldn't connect to JFrog Xray. Please check your credentials.", e);
+                return false;
+            }
+            return xrayClient.entitlements().isEntitled(getScannerFeatureName());
+        }
+    }
+
     protected List<String> getSupportedLanguages() {
         return supportedLanguages;
     }
@@ -133,11 +181,89 @@ public abstract class ScanBinaryExecutor {
         return om.readValue(outputFile.toFile(), Output.class);
     }
 
+    protected void downloadBinary() throws IOException {
+        try (ArtifactoryManager artifactoryManager = artifactoryManagerBuilder.build()) {
+            String downloadUrl = getBinaryDownloadURL();
+            File downloadBinary = artifactoryManager.downloadToFile(downloadUrl, BINARY_TARGET_PATH.toString());
+            if (downloadBinary == null) {
+                throw new IOException("An empty response received from Artifactory.");
+            }
+            downloadBinary.setExecutable(true);
+        }
+    }
+
     Path createTempRunInputFile(ScansConfig scanInput) throws IOException {
         ObjectMapper om = createYAMLMapper();
         Path tempDir = Files.createTempDirectory("");
         Path inputPath = Files.createTempFile(tempDir, "", ".yaml");
         om.writeValue(inputPath.toFile(), scanInput);
         return inputPath;
+    }
+
+    private Map<String, String> creatEnvWithCredentials() {
+        Map<String, String> env = new HashMap<>(EnvironmentUtil.getEnvironmentMap());
+        ServerConfigImpl serverConfig = GlobalSettings.getInstance().getServerConfig();
+        if (serverConfig.isXrayConfigured()) {
+            env.put(ENV_PLATFORM, serverConfig.getUrl());
+            if (StringUtils.isNotEmpty(serverConfig.getAccessToken())) {
+                env.put(ENV_ACCESS_TOKEN, serverConfig.getAccessToken());
+            } else {
+                env.put(ENV_USER, serverConfig.getUsername());
+                env.put(ENV_PASSWORD, serverConfig.getPassword());
+            }
+
+            ProxyConfiguration proxyConfiguration = serverConfig.getProxyConfForTargetUrl(serverConfig.getUrl());
+            if (proxyConfiguration != null) {
+                String proxyUrl = proxyConfiguration.host + ":" + proxyConfiguration.port;
+                if (StringUtils.isNoneBlank(proxyConfiguration.username, proxyConfiguration.password)) {
+                    proxyUrl = proxyConfiguration.username + ":" + proxyConfiguration.password + "@" + proxyUrl;
+                }
+                env.put(ENV_HTTP_PROXY, "http://" + proxyUrl);
+                env.put(ENV_HTTPS_PROXY, "https://" + proxyUrl);
+            }
+        }
+        return env;
+    }
+
+    private static String getOSAndArc() throws IOException {
+        String arch = SystemUtils.OS_ARCH;
+        // Windows
+        if (SystemUtils.IS_OS_WINDOWS) {
+            return "windows-amd64";
+        }
+        // Mac
+        if (SystemUtils.IS_OS_MAC) {
+            if (arch == "arm64") {
+                return "mac-arm64";
+            } else {
+                return "mac-amd64";
+            }
+        }
+        // Linux
+        if (SystemUtils.IS_OS_LINUX) {
+            switch (arch) {
+                case "i386":
+                case "i486":
+                case "i586":
+                case "i686":
+                case "i786":
+                case "x86":
+                    return "linux-386";
+                case "amd64":
+                case "x86_64":
+                case "x64":
+                    return "linux-amd64";
+                case "arm":
+                case "armv7l":
+                    return "linux-arm";
+                case "aarch64":
+                    return "linux-arm64";
+                case "s390x":
+                case "ppc64":
+                case "ppc64le":
+                    return "linux-" + arch;
+            }
+        }
+        throw new IOException(String.format("Unsupported OS: %s-%s", SystemUtils.OS_NAME, arch));
     }
 }

--- a/src/main/java/com/jfrog/ide/idea/scan/SourceCodeScannerManager.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/SourceCodeScannerManager.java
@@ -14,7 +14,6 @@ import org.apache.commons.lang.StringUtils;
 
 import javax.swing.tree.TreeNode;
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
@@ -59,8 +58,7 @@ public class SourceCodeScannerManager {
                 List<JFrogSecurityWarning> applicabilityResults = applicability.execute(new ScanConfig.Builder().roots(List.of(getProjectBasePath(project).toString())).cves(List.copyOf(issuesMap.keySet())).skippedFolders(getSkippedFoldersPatterns()));
                 scanResults.addAll(applicabilityResults);
             }
-        } catch (IOException | InterruptedException | URISyntaxException |
-                 NullPointerException e) {
+        } catch (IOException | InterruptedException | NullPointerException e) {
             logError(Logger.getInstance(), "Failed to scan source code", e, true);
         } finally {
             scanInProgress.set(false);

--- a/src/main/java/com/jfrog/ide/idea/scan/SourceCodeScannerManager.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/SourceCodeScannerManager.java
@@ -14,6 +14,7 @@ import org.apache.commons.lang.StringUtils;
 
 import javax.swing.tree.TreeNode;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
@@ -24,7 +25,6 @@ import static com.jfrog.ide.idea.utils.Utils.getProjectBasePath;
 
 public class SourceCodeScannerManager {
     private final AtomicBoolean scanInProgress = new AtomicBoolean(false);
-
     private final Eos eos = new Eos();
     private final ApplicabilityScannerExecutor applicability = new ApplicabilityScannerExecutor();
 
@@ -66,7 +66,7 @@ public class SourceCodeScannerManager {
                 List<JFrogSecurityWarning> eosResults = eos.execute(new ScanConfig.Builder().language(codeBaseLanguage).roots(List.of(getProjectBasePath(project).toString())));
                 scanResults.addAll(eosResults);
             }
-        } catch (IOException | InterruptedException |
+        } catch (IOException | InterruptedException | URISyntaxException |
                  NullPointerException e) {
             logError(Logger.getInstance(), "Failed to scan source code", e, true);
         } finally {

--- a/src/main/java/com/jfrog/ide/idea/scan/SourceCodeScannerManager.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/SourceCodeScannerManager.java
@@ -25,7 +25,7 @@ import static com.jfrog.ide.idea.utils.Utils.getProjectBasePath;
 
 public class SourceCodeScannerManager {
     private final AtomicBoolean scanInProgress = new AtomicBoolean(false);
-    private final ApplicabilityScannerExecutor applicability = new ApplicabilityScannerExecutor(Logger.getInstance());
+    private final ApplicabilityScannerExecutor applicability = new ApplicabilityScannerExecutor(Logger.getInstance(), GlobalSettings.getInstance().getServerConfig());
 
     protected Project project;
     protected String codeBaseLanguage;

--- a/src/main/java/com/jfrog/ide/idea/scan/SourceCodeScannerManager.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/SourceCodeScannerManager.java
@@ -25,7 +25,6 @@ import static com.jfrog.ide.idea.utils.Utils.getProjectBasePath;
 
 public class SourceCodeScannerManager {
     private final AtomicBoolean scanInProgress = new AtomicBoolean(false);
-    private final Eos eos = new Eos();
     private final ApplicabilityScannerExecutor applicability = new ApplicabilityScannerExecutor();
 
     protected Project project;
@@ -59,12 +58,6 @@ public class SourceCodeScannerManager {
                 indicator.setFraction(0.25);
                 List<JFrogSecurityWarning> applicabilityResults = applicability.execute(new ScanConfig.Builder().roots(List.of(getProjectBasePath(project).toString())).cves(List.copyOf(issuesMap.keySet())).skippedFolders(getSkippedFoldersPatterns()));
                 scanResults.addAll(applicabilityResults);
-            }
-            if (eos.getSupportedLanguages().contains(codeBaseLanguage)) {
-                indicator.setText("Running Eos scan");
-                indicator.setFraction(0.5);
-                List<JFrogSecurityWarning> eosResults = eos.execute(new ScanConfig.Builder().language(codeBaseLanguage).roots(List.of(getProjectBasePath(project).toString())));
-                scanResults.addAll(eosResults);
             }
         } catch (IOException | InterruptedException | URISyntaxException |
                  NullPointerException e) {

--- a/src/main/java/com/jfrog/ide/idea/scan/data/Region.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/data/Region.java
@@ -7,50 +7,50 @@ import java.util.Objects;
 public class Region {
 
     @JsonProperty("endColumn")
-    private Integer endColumn;
+    private int endColumn;
     @JsonProperty("endLine")
-    private Integer endLine;
+    private int endLine;
     @JsonProperty("startColumn")
-    private Integer startColumn;
+    private int startColumn;
     @JsonProperty("startLine")
-    private Integer startLine;
+    private int startLine;
     @JsonProperty("snippet")
 
     private Message snippet;
 
-    public Integer getEndColumn() {
+    public int getEndColumn() {
         return endColumn;
     }
 
     @SuppressWarnings("unused")
-    public void setEndColumn(Integer endColumn) {
+    public void setEndColumn(int endColumn) {
         this.endColumn = endColumn;
     }
 
-    public Integer getEndLine() {
+    public int getEndLine() {
         return endLine;
     }
 
     @SuppressWarnings("unused")
-    public void setEndLine(Integer endLine) {
+    public void setEndLine(int endLine) {
         this.endLine = endLine;
     }
 
-    public Integer getStartColumn() {
+    public int getStartColumn() {
         return startColumn;
     }
 
     @SuppressWarnings("unused")
-    public void setStartColumn(Integer startColumn) {
+    public void setStartColumn(int startColumn) {
         this.startColumn = startColumn;
     }
 
-    public Integer getStartLine() {
+    public int getStartLine() {
         return startLine;
     }
 
     @SuppressWarnings("unused")
-    public void setStartLine(Integer startLine) {
+    public void setStartLine(int startLine) {
         this.startLine = startLine;
     }
 

--- a/src/main/java/com/jfrog/ide/idea/scan/data/SarifResult.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/data/SarifResult.java
@@ -17,9 +17,15 @@ public class SarifResult {
     private String ruleId;
     @JsonProperty("codeFlows")
     private List<CodeFlow> codeFlows = new ArrayList<>();
+    @JsonProperty("kind")
+    private String kind;
 
     public Message getMessage() {
         return message;
+    }
+
+    public String getKind() {
+        return kind != null ? kind : "";
     }
 
     public void setMessage(Message message) {
@@ -29,6 +35,7 @@ public class SarifResult {
     public List<Location> getLocations() {
         return locations;
     }
+
     @SuppressWarnings({"unused"})
     public void setLocations(List<Location> locations) {
         this.locations = locations;
@@ -37,14 +44,17 @@ public class SarifResult {
     public String getRuleId() {
         return ruleId;
     }
+
     @SuppressWarnings({"unused"})
     public void setRuleId(String ruleId) {
         this.ruleId = ruleId;
     }
+
     @SuppressWarnings({"unused"})
     public List<CodeFlow> getCodeFlows() {
         return codeFlows;
     }
+
     @SuppressWarnings({"unused"})
     public void setCodeFlows(List<CodeFlow> codeFlows) {
         this.codeFlows = codeFlows;

--- a/src/main/java/com/jfrog/ide/idea/scan/data/SarifResult.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/data/SarifResult.java
@@ -2,6 +2,7 @@ package com.jfrog.ide.idea.scan.data;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,7 +26,7 @@ public class SarifResult {
     }
 
     public String getKind() {
-        return kind != null ? kind : "";
+        return StringUtils.defaultString(kind);
     }
 
     public void setMessage(Message message) {

--- a/src/main/java/com/jfrog/ide/idea/utils/Utils.java
+++ b/src/main/java/com/jfrog/ide/idea/utils/Utils.java
@@ -9,28 +9,20 @@ import com.intellij.openapi.wm.ToolWindowManager;
 import com.jfrog.ide.idea.configuration.GlobalSettings;
 import com.jfrog.ide.idea.configuration.ServerConfigImpl;
 import com.jfrog.ide.idea.log.Logger;
-import org.apache.commons.codec.net.URLCodec;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.jfrog.build.extractor.scan.DependencyTree;
 import org.jfrog.build.extractor.scan.GeneralInfo;
 import org.jfrog.build.extractor.usageReport.UsageReporter;
-import org.jfrog.build.util.URI;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Collections;
-
-import static org.apache.commons.codec.binary.StringUtils.getBytesUtf8;
-import static org.apache.commons.codec.binary.StringUtils.newStringUsAscii;
 
 /**
  * Created by romang on 5/8/17.
@@ -82,19 +74,6 @@ public class Utils {
             log.debug("Usage report failed: " + ExceptionUtils.getRootCauseMessage(e));
         }
         log.debug("Usage report sent successfully.");
-    }
-
-    /**
-     * Returns the file sha256 (checksum) from a remote server.
-     *
-     * @param url the requested file URL
-     * @return the file checksum.
-     */
-    public static String getFileChecksumFromServer(String url) throws IOException, InterruptedException, URISyntaxException {
-        byte[] rawData = URLCodec.encodeUrl(URI.allowed_query, getBytesUtf8(url));
-        HttpRequest headRequest = HttpRequest.newBuilder(new URL(newStringUsAscii(rawData)).toURI()).method("HEAD", HttpRequest.BodyPublishers.noBody()).build();
-        HttpResponse<String> checksumResponse = HttpClient.newHttpClient().send(headRequest, HttpResponse.BodyHandlers.ofString());
-        return checksumResponse.headers().firstValue("x-checksum-sha256").get();
     }
 
     /**

--- a/src/main/java/com/jfrog/ide/idea/utils/Utils.java
+++ b/src/main/java/com/jfrog/ide/idea/utils/Utils.java
@@ -9,20 +9,28 @@ import com.intellij.openapi.wm.ToolWindowManager;
 import com.jfrog.ide.idea.configuration.GlobalSettings;
 import com.jfrog.ide.idea.configuration.ServerConfigImpl;
 import com.jfrog.ide.idea.log.Logger;
+import org.apache.commons.codec.net.URLCodec;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.jfrog.build.extractor.scan.DependencyTree;
 import org.jfrog.build.extractor.scan.GeneralInfo;
 import org.jfrog.build.extractor.usageReport.UsageReporter;
+import org.jfrog.build.util.URI;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Collections;
+
+import static org.apache.commons.codec.binary.StringUtils.getBytesUtf8;
+import static org.apache.commons.codec.binary.StringUtils.newStringUsAscii;
 
 /**
  * Created by romang on 5/8/17.
@@ -74,6 +82,19 @@ public class Utils {
             log.debug("Usage report failed: " + ExceptionUtils.getRootCauseMessage(e));
         }
         log.debug("Usage report sent successfully.");
+    }
+
+    /**
+     * Returns the file sha256 (checksum) from a remote server.
+     *
+     * @param url the requested file URL
+     * @return the file checksum.
+     */
+    public static String getFileChecksumFromServer(String url) throws IOException, InterruptedException, URISyntaxException {
+        byte[] rawData = URLCodec.encodeUrl(URI.allowed_query, getBytesUtf8(url));
+        HttpRequest headRequest = HttpRequest.newBuilder(new URL(newStringUsAscii(rawData)).toURI()).method("HEAD", HttpRequest.BodyPublishers.noBody()).build();
+        HttpResponse<String> checksumResponse = HttpClient.newHttpClient().send(headRequest, HttpResponse.BodyHandlers.ofString());
+        return checksumResponse.headers().firstValue("x-checksum-sha256").get();
     }
 
     /**

--- a/src/test/java/com/jfrog/ide/idea/ServerConfigStub.java
+++ b/src/test/java/com/jfrog/ide/idea/ServerConfigStub.java
@@ -1,0 +1,78 @@
+package com.jfrog.ide.idea;
+
+import com.jfrog.ide.common.configuration.ServerConfig;
+import org.jfrog.build.client.ProxyConfiguration;
+
+import javax.net.ssl.SSLContext;
+
+public class ServerConfigStub implements ServerConfig {
+    @Override
+    public String getUrl() {
+        return "";
+    }
+
+    @Override
+    public String getXrayUrl() {
+        return "";
+    }
+
+    @Override
+    public String getArtifactoryUrl() {
+        return "";
+    }
+
+    @Override
+    public String getUsername() {
+        return "";
+    }
+
+    @Override
+    public String getPassword() {
+        return "";
+    }
+
+    @Override
+    public String getAccessToken() {
+        return "";
+    }
+
+    @Override
+    public PolicyType getPolicyType() {
+        return null;
+    }
+
+    @Override
+    public String getProject() {
+        return "";
+    }
+
+    @Override
+    public String getWatches() {
+        return "";
+    }
+
+    @Override
+    public boolean isInsecureTls() {
+        return false;
+    }
+
+    @Override
+    public SSLContext getSslContext() {
+        return null;
+    }
+
+    @Override
+    public ProxyConfiguration getProxyConfForTargetUrl(String xrayUrl) {
+        return null;
+    }
+
+    @Override
+    public int getConnectionRetries() {
+        return 0;
+    }
+
+    @Override
+    public int getConnectionTimeout() {
+        return 0;
+    }
+}

--- a/src/test/java/com/jfrog/ide/idea/scan/ScanBinaryExecutorTest.java
+++ b/src/test/java/com/jfrog/ide/idea/scan/ScanBinaryExecutorTest.java
@@ -1,15 +1,19 @@
 package com.jfrog.ide.idea.scan;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jfrog.ide.idea.ServerConfigStub;
 import com.jfrog.ide.idea.inspections.JFrogSecurityWarning;
 import com.jfrog.ide.idea.scan.data.ScanConfig;
 import com.jfrog.ide.idea.scan.data.ScansConfig;
 import junit.framework.TestCase;
 import org.apache.commons.io.FileUtils;
+import org.gradle.internal.impldep.org.testng.annotations.Test;
 import org.jfrog.build.api.util.NullLog;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -19,7 +23,7 @@ import static com.jfrog.ide.common.utils.Utils.createYAMLMapper;
  * @author tala
  **/
 public class ScanBinaryExecutorTest extends TestCase {
-    private final ScanBinaryExecutor scanner = new ApplicabilityScannerExecutor(new NullLog());
+    private final ScanBinaryExecutor scanner = new ApplicabilityScannerExecutor(new NullLog(), new ServerConfigStub());
     private final Path SIMPLE_OUTPUT = new File("src/test/resources/applicability/simple_output.sarif").toPath();
     private final Path NOT_APPLIC_OUTPUT = new File("src/test/resources/applicability/not_applic_output.sarif").toPath();
 

--- a/src/test/java/com/jfrog/ide/idea/scan/ScanBinaryExecutorTest.java
+++ b/src/test/java/com/jfrog/ide/idea/scan/ScanBinaryExecutorTest.java
@@ -7,13 +7,10 @@ import com.jfrog.ide.idea.scan.data.ScanConfig;
 import com.jfrog.ide.idea.scan.data.ScansConfig;
 import junit.framework.TestCase;
 import org.apache.commons.io.FileUtils;
-import org.gradle.internal.impldep.org.testng.annotations.Test;
 import org.jfrog.build.api.util.NullLog;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URISyntaxException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 

--- a/src/test/java/com/jfrog/ide/idea/scan/ScanBinaryExecutorTest.java
+++ b/src/test/java/com/jfrog/ide/idea/scan/ScanBinaryExecutorTest.java
@@ -6,6 +6,7 @@ import com.jfrog.ide.idea.scan.data.ScanConfig;
 import com.jfrog.ide.idea.scan.data.ScansConfig;
 import junit.framework.TestCase;
 import org.apache.commons.io.FileUtils;
+import org.jfrog.build.api.util.NullLog;
 
 import java.io.File;
 import java.io.IOException;
@@ -18,7 +19,7 @@ import static com.jfrog.ide.common.utils.Utils.createYAMLMapper;
  * @author tala
  **/
 public class ScanBinaryExecutorTest extends TestCase {
-    private final ScanBinaryExecutor scanner = new ApplicabilityScannerExecutor();
+    private final ScanBinaryExecutor scanner = new ApplicabilityScannerExecutor(new NullLog());
     private final Path SIMPLE_OUTPUT = new File("src/test/resources/applicability/simple_output.sarif").toPath();
     private final Path NOT_APPLIC_OUTPUT = new File("src/test/resources/applicability/not_applic_output.sarif").toPath();
 

--- a/src/test/resources/applicability/not_applic_output.sarif
+++ b/src/test/resources/applicability/not_applic_output.sarif
@@ -110,6 +110,20 @@
                         }
                     ],
                     "ruleId": "CVE-2022-25978"
+                },
+                {
+                    "message": {
+                        "text": "The scanner checks whether the vulnerable function `ansi-regex` is called."
+                    },
+                    "kind": "pass",
+                    "ruleId": "applic_CVE-2021-25878"
+                },
+                {
+                    "message": {
+                        "text": "The scanner checks whether the vulnerable function `ansi-regex` is called."
+                    },
+                    "kind": "pass",
+                    "ruleId": "applic_CVE-2022-29019"
                 }
             ]
         }

--- a/src/test/resources/applicability/simple_output.sarif
+++ b/src/test/resources/applicability/simple_output.sarif
@@ -54,12 +54,12 @@
                                     "uri": "examples/applic-demo/../applic-demo/index.js"
                                 },
                                 "region": {
-                                    "endColumn": 17,
+                                    "endColumn": 18,
                                     "endLine": 20,
                                     "snippet": {
                                         "text": "protobuf.parse(p)"
                                     },
-                                    "startColumn": 0,
+                                    "startColumn": 1,
                                     "startLine": 20
                                 }
                             }
@@ -78,12 +78,12 @@
                                     "uri": "file://examples/applic-demo/../applic-demo/index.js"
                                 },
                                 "region": {
-                                    "endColumn": 73,
+                                    "endColumn": 74,
                                     "endLine": 22,
                                     "snippet": {
                                         "text": "protobuf.load(\"/path/to/untrusted.proto\", function(err, root) { return })"
                                     },
-                                    "startColumn": 0,
+                                    "startColumn": 1,
                                     "startLine": 18
                                 }
                             }


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
This PR adds support for downloading the new AnalyzerManager.
As well as adapting the SARIF parsing to the new AnalyzerManager output.