### PR TITLE
Disable navigation from cached results

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     implementation group: 'com.jfrog.xray.client', name: 'xray-client-java', version: '0.14.0'
     implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
     implementation group: 'org.jfrog.filespecs', name: 'file-specs-java', version: '1.1.2'
-    implementation group: 'com.jfrog.ide', name: 'ide-plugins-common', version: '1.13.x-20230222.095001-2'
+    implementation group: 'com.jfrog.ide', name: 'ide-plugins-common', version: '1.13.x-20230223.164532-3'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.11'
     implementation group: 'com.google.guava', name: 'guava', version: '30.1.1-jre'
     testImplementation group: 'org.mockito', name: 'mockito-inline', version: '4.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.14.0'
     implementation group: 'org.jfrog.buildinfo', name: 'build-info-api', version: buildInfoVersion
     implementation group: 'net.lingala.zip4j', name: 'zip4j', version: '2.11.4'
-    implementation group: 'com.jfrog.xray.client', name: 'xray-client-java', version: '0.13.x-20230219.172211-1'
+    implementation group: 'com.jfrog.xray.client', name: 'xray-client-java', version: '0.14.0'
     implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
     implementation group: 'org.jfrog.filespecs', name: 'file-specs-java', version: '1.1.2'
     implementation group: 'com.jfrog.ide', name: 'ide-plugins-common', version: '1.13.x-20230222.095001-2'

--- a/src/main/java/com/jfrog/ide/idea/ui/LocalComponentsTree.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/LocalComponentsTree.java
@@ -138,6 +138,9 @@ public class LocalComponentsTree extends ComponentsTree {
     }
 
     private void addNodeNavigation(Set<NavigationTarget> navigationCandidates) {
+        if (navigationCandidates == null) {
+            return;
+        }
         if (navigationCandidates.size() > 1) {
             addMultiNavigation(navigationCandidates);
         } else {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
When cached results are shown, inspections didn't run yet, so navigation is not available.