### PR TITLE
Fix applicability scan exclude directories 

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/scan/SourceCodeScannerManager.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/SourceCodeScannerManager.java
@@ -28,6 +28,7 @@ public class SourceCodeScannerManager {
 
     protected Project project;
     protected String codeBaseLanguage;
+    public static final String SKIP_FOLDERS_SUFFIX = "*/**";
 
     public SourceCodeScannerManager(Project project, String codeBaseLanguage) {
         this.project = project;
@@ -51,6 +52,8 @@ public class SourceCodeScannerManager {
         }
         List<JFrogSecurityWarning> scanResults = new ArrayList<>();
         Map<String, List<VulnerabilityNode>> issuesMap = mapDirectIssuesByCve(depScanResults);
+        String excludePattern = GlobalSettings.getInstance().getServerConfig().getExcludedPaths();
+
         try {
             if (applicability.getSupportedLanguages().contains(codeBaseLanguage)) {
                 indicator.setText("Running applicability scan");
@@ -58,7 +61,7 @@ public class SourceCodeScannerManager {
                 Set<String> directIssuesCVEs = issuesMap.keySet();
                 // If no direct dependencies with issues are found by Xray, the applicability scan is irrelevant.
                 if (directIssuesCVEs.size() > 0) {
-                    List<JFrogSecurityWarning> applicabilityResults = applicability.execute(new ScanConfig.Builder().roots(List.of(getProjectBasePath(project).toString())).cves(List.copyOf(directIssuesCVEs)).skippedFolders(getSkippedFoldersPatterns()));
+                    List<JFrogSecurityWarning> applicabilityResults = applicability.execute(new ScanConfig.Builder().roots(List.of(getProjectBasePath(project).toString())).cves(List.copyOf(directIssuesCVEs)).skippedFolders(convertToSkippedFolders(excludePattern)));
                     scanResults.addAll(applicabilityResults);
                 }
             }
@@ -77,17 +80,17 @@ public class SourceCodeScannerManager {
      *
      * @return a list of equivalent patterns without the use of "{}"
      */
-    private List<String> getSkippedFoldersPatterns() {
-        String excludePattern = GlobalSettings.getInstance().getServerConfig().getExcludedPaths();
+    static List<String> convertToSkippedFolders(String excludePattern) {
         List<String> skippedFoldersPatterns = new ArrayList<>();
         if (StringUtils.isNotBlank(excludePattern)) {
             Matcher matcher = EXCLUSIONS_REGEX_PATTERN.matcher(excludePattern);
             if (!matcher.find()) {
-                return List.of(excludePattern);
+                // Convert pattern form shape "**/*a*" to "**/*a*/**"
+                return List.of(StringUtils.removeEnd(excludePattern, EXCLUSIONS_SUFFIX) + SKIP_FOLDERS_SUFFIX);
             }
             String[] dirsNames = matcher.group(1).split(",");
             for (String dirName : dirsNames) {
-                skippedFoldersPatterns.add(EXCLUSIONS_PREFIX + dirName.strip() + EXCLUSIONS_SUFFIX);
+                skippedFoldersPatterns.add(EXCLUSIONS_PREFIX + dirName.strip() + SKIP_FOLDERS_SUFFIX);
             }
         }
         return skippedFoldersPatterns;

--- a/src/main/java/com/jfrog/ide/idea/scan/SourceCodeScannerManager.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/SourceCodeScannerManager.java
@@ -28,7 +28,7 @@ public class SourceCodeScannerManager {
 
     protected Project project;
     protected String codeBaseLanguage;
-    public static final String SKIP_FOLDERS_SUFFIX = "*/**";
+    private static final String SKIP_FOLDERS_SUFFIX = "*/**";
 
     public SourceCodeScannerManager(Project project, String codeBaseLanguage) {
         this.project = project;

--- a/src/main/java/com/jfrog/ide/idea/ui/configuration/ConfigVerificationUtils.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/configuration/ConfigVerificationUtils.java
@@ -21,7 +21,7 @@ public class ConfigVerificationUtils {
     public static final String EXCLUSIONS_SUFFIX = "*";
     public static String EXCLUSIONS_REGEX_PARSER = "^\\*\\*/\\*\\{([^{}]+)}\\*$";
     public static Pattern EXCLUSIONS_REGEX_PATTERN = Pattern.compile(EXCLUSIONS_REGEX_PARSER);
-    public static final String DEFAULT_EXCLUSIONS = EXCLUSIONS_PREFIX + "{.idea, test, node_modules}" + EXCLUSIONS_SUFFIX;
+    public static final String DEFAULT_EXCLUSIONS = EXCLUSIONS_PREFIX + "{.idea,test,node_modules}" + EXCLUSIONS_SUFFIX;
 
     /**
      * Validate config project, watches and excluded paths before saving.
@@ -46,6 +46,7 @@ public class ConfigVerificationUtils {
 
     /**
      * Validate excluded paths field before saving.
+     *
      * @param excludedPaths users' input parameter
      * @throws ConfigurationException if excludedPaths field in the configuration is illegal.
      */
@@ -60,7 +61,7 @@ public class ConfigVerificationUtils {
             try {
                 FileSystems.getDefault().getPathMatcher("glob:" + excludedPaths);
             } catch (PatternSyntaxException e) {
-                throw new ConfigurationException(ExceptionUtils.getRootCauseMessage(e),"Excluded paths pattern must be a valid glob pattern");
+                throw new ConfigurationException(ExceptionUtils.getRootCauseMessage(e), "Excluded paths pattern must be a valid glob pattern");
             }
             Matcher matcher = EXCLUSIONS_REGEX_PATTERN.matcher(excludedPaths);
             if (!matcher.find()) {

--- a/src/main/java/com/jfrog/ide/idea/ui/configuration/JFrogGlobalConfiguration.form
+++ b/src/main/java/com/jfrog/ide/idea/ui/configuration/JFrogGlobalConfiguration.form
@@ -652,7 +652,7 @@
             </constraints>
             <properties>
               <enabled value="false"/>
-              <text value="    Which is used to exclude specific local paths from being scanned by JFrog Xray."/>
+              <text value="    Which is used to exclude specific local directories paths from being scanned by the plugin."/>
             </properties>
           </component>
         </children>

--- a/src/main/java/com/jfrog/ide/idea/ui/configuration/JFrogGlobalConfiguration.form
+++ b/src/main/java/com/jfrog/ide/idea/ui/configuration/JFrogGlobalConfiguration.form
@@ -507,7 +507,7 @@
             </constraints>
             <properties>
               <text value="    Excluded directories"/>
-              <toolTipText value="Pattern of project paths to exclude from Xray scanning for npm and Go projects."/>
+              <toolTipText value=""/>
             </properties>
           </component>
           <component id="a1d59" class="com.intellij.ui.components.JBTextField" binding="excludedPaths">

--- a/src/main/java/com/jfrog/ide/idea/ui/configuration/JFrogGlobalConfiguration.form
+++ b/src/main/java/com/jfrog/ide/idea/ui/configuration/JFrogGlobalConfiguration.form
@@ -506,7 +506,7 @@
               </grid>
             </constraints>
             <properties>
-              <text value="    Excluded paths"/>
+              <text value="    Excluded directories"/>
               <toolTipText value="Pattern of project paths to exclude from Xray scanning for npm and Go projects."/>
             </properties>
           </component>

--- a/src/test/java/com/jfrog/ide/idea/scan/SourceCodeManagerTest.java
+++ b/src/test/java/com/jfrog/ide/idea/scan/SourceCodeManagerTest.java
@@ -10,32 +10,30 @@ import java.util.Collection;
 
 import static com.jfrog.ide.idea.scan.SourceCodeScannerManager.convertToSkippedFolders;
 
+@RunWith(Parameterized.class)
 public class SourceCodeManagerTest {
 
-    @RunWith(Parameterized.class)
-    public static class ConvertToSkipFoldersTest {
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {"", new String[]{}},
+                {"**/*{.idea}*", new String[]{"**/*.idea*/**"}},
+                {"**/*.idea*", new String[]{"**/*.idea*/**"}},
+                {"**/*{.idea,test,node_modules}*", new String[]{"**/*.idea*/**", "**/*test*/**", "**/*node_modules*/**"}},
+        });
+    }
 
-        @Parameterized.Parameters
-        public static Collection<Object[]> data() {
-            return Arrays.asList(new Object[][]{
-                    {"", new String[]{}},
-                    {"**/*{.idea}*", new String[]{"**/*.idea*/**"}},
-                    {"**/*.idea*", new String[]{"**/*.idea*/**"}},
-                    {"**/*{.idea,test,node_modules}*", new String[]{"**/*.idea*/**", "**/*test*/**", "**/*node_modules*/**"}},
-            });
-        }
+    private final String excludedPaths;
+    private final String[] skipFolders;
 
-        private final String excludedPaths;
-        private final String[] skipFolders;
+    public SourceCodeManagerTest(String excludedPaths, String[] skipFolders) {
+        this.excludedPaths = excludedPaths;
+        this.skipFolders = skipFolders;
+    }
 
-        public ConvertToSkipFoldersTest(String excludedPaths, String[] skipFolders) {
-            this.excludedPaths = excludedPaths;
-            this.skipFolders = skipFolders;
-        }
-
-        @Test
-        public void testConvertToSkippedFolders() {
-            Assert.assertArrayEquals(skipFolders, convertToSkippedFolders(excludedPaths).toArray());
-        }
+    @Test
+    public void testConvertToSkippedFolders() {
+        Assert.assertArrayEquals(skipFolders, convertToSkippedFolders(excludedPaths).toArray());
     }
 }
+

--- a/src/test/java/com/jfrog/ide/idea/scan/SourceCodeManagerTest.java
+++ b/src/test/java/com/jfrog/ide/idea/scan/SourceCodeManagerTest.java
@@ -1,0 +1,41 @@
+package com.jfrog.ide.idea.scan;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static com.jfrog.ide.idea.scan.SourceCodeScannerManager.convertToSkippedFolders;
+
+public class SourceCodeManagerTest {
+
+    @RunWith(Parameterized.class)
+    public static class ConvertToSkipFoldersTest {
+
+        @Parameterized.Parameters
+        public static Collection<Object[]> data() {
+            return Arrays.asList(new Object[][]{
+                    {"", new String[]{}},
+                    {"**/*{.idea}*", new String[]{"**/*.idea*/**"}},
+                    {"**/*.idea*", new String[]{"**/*.idea*/**"}},
+                    {"**/*{.idea,test,node_modules}*", new String[]{"**/*.idea*/**", "**/*test*/**", "**/*node_modules*/**"}},
+            });
+        }
+
+        private final String excludedPaths;
+        private final String[] skipFolders;
+
+        public ConvertToSkipFoldersTest(String excludedPaths, String[] skipFolders) {
+            this.excludedPaths = excludedPaths;
+            this.skipFolders = skipFolders;
+        }
+
+        @Test
+        public void testConvertToSkippedFolders() {
+            Assert.assertArrayEquals(skipFolders, convertToSkippedFolders(excludedPaths).toArray());
+        }
+    }
+}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
Add the missing "*/**" to the Applicability skip folders pattern.