### PR TITLE
Android Studio incompatibility

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -28,6 +28,7 @@
     <depends config-file="with-go.xml" optional="true">org.jetbrains.plugins.go</depends>
     <depends config-file="with-python.xml" optional="true">com.intellij.modules.python</depends>
     <depends config-file="with-python-ce.xml" optional="true">PythonCore</depends>
+    <incompatible-with>com.intellij.modules.androidstudio</incompatible-with>
 
     <application-components>
         <component>


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
Setting the plugin as incompatible with Android Studio due to JCEF being not bundled in Android Studio by default.