### PR TITLE
Add new "empty state" for scan interruptions and improve error handling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     implementation group: 'com.jfrog.xray.client', name: 'xray-client-java', version: '0.14.0'
     implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
     implementation group: 'org.jfrog.filespecs', name: 'file-specs-java', version: '1.1.2'
-    implementation group: 'com.jfrog.ide', name: 'ide-plugins-common', version: '2.0.1'
+    implementation group: 'com.jfrog.ide', name: 'ide-plugins-common', version: '2.0.x-20230402.081604-2'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.11'
     implementation group: 'com.google.guava', name: 'guava', version: '30.1.1-jre'
     testImplementation group: 'org.mockito', name: 'mockito-inline', version: '4.2.0'

--- a/src/main/java/com/jfrog/ide/idea/scan/ScanManager.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ScanManager.java
@@ -164,5 +164,4 @@ public class ScanManager {
         }
         return new GraphScanLogic(logger);
     }
-
 }

--- a/src/main/java/com/jfrog/ide/idea/ui/JFrogLocalToolWindow.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/JFrogLocalToolWindow.java
@@ -289,6 +289,13 @@ public class JFrogLocalToolWindow extends AbstractJFrogToolWindow {
      */
     @Override
     public void onConfigurationChange() {
+        if (componentsTree != null) {
+            try {
+                componentsTree.deleteCachedTree();
+            } catch (IOException e) {
+                Logger.getInstance().warn("Error: " + ExceptionUtils.getRootCauseMessage(e));
+            }
+        }
         super.onConfigurationChange();
         refreshView();
     }

--- a/src/main/java/com/jfrog/ide/idea/ui/JFrogLocalToolWindow.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/JFrogLocalToolWindow.java
@@ -293,7 +293,7 @@ public class JFrogLocalToolWindow extends AbstractJFrogToolWindow {
             try {
                 componentsTree.deleteCachedTree();
             } catch (IOException e) {
-                Logger.getInstance().warn("Error: " + ExceptionUtils.getRootCauseMessage(e));
+                Logger.getInstance().warn("An error occurred while trying to delete the scan results cache: " + ExceptionUtils.getRootCauseMessage(e));
             }
         }
         super.onConfigurationChange();

--- a/src/main/java/com/jfrog/ide/idea/ui/LocalComponentsTree.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/LocalComponentsTree.java
@@ -39,6 +39,8 @@ public class LocalComponentsTree extends ComponentsTree {
     public static final String IGNORE_RULE_TOOL_TIP = "Creating Ignore Rules is only available when a JFrog Project or Watch is defined.";
     private static final String SHOW_IN_PROJECT_DESCRIPTOR = "Show direct dependency in project descriptor";
     private static final String NO_ISSUES = "Your project was scanned and we didn't find any security issues.";
+    private static final String ERROR_WHILE_SCANNING = "An error occurred while your project was scanned. Please see the Notifications log for more details.";
+
     private static final String SCANNING = "Scanning...";
     private static final long EXPIRED_CACHE_TIME = TimeUnit.DAYS.toMillis(7); // week
 
@@ -57,11 +59,6 @@ public class LocalComponentsTree extends ComponentsTree {
 
     public static LocalComponentsTree getInstance(@NotNull Project project) {
         return project.getService(LocalComponentsTree.class);
-    }
-
-    @Override
-    public void reset() {
-        super.reset();
     }
 
     public void addScanResults(List<FileTreeNode> fileTreeNodes) {
@@ -188,6 +185,10 @@ public class LocalComponentsTree extends ComponentsTree {
         cache.cacheNodes((List<FileTreeNode>) (List<?>) Collections.list(root.children()));
     }
 
+    public void deleteCachedTree() throws IOException {
+        cache.deleteScanCacheObject();
+    }
+
     private void setNodesFromCache() {
         ScanCacheObject cacheObject = cache.getScanCacheObject();
         if (cacheObject == null) {
@@ -235,4 +236,12 @@ public class LocalComponentsTree extends ComponentsTree {
     public void setNoIssuesEmptyText() {
         getEmptyText().setText(NO_ISSUES);
     }
+
+    /**
+     * Sets the empty text to indicate that during the project scan an error occurred.
+     */
+    public void setScanErrorEmptyText() {
+        getEmptyText().setText(ERROR_WHILE_SCANNING);
+    }
+
 }

--- a/src/main/java/com/jfrog/ide/idea/ui/LocalComponentsTree.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/LocalComponentsTree.java
@@ -39,7 +39,7 @@ public class LocalComponentsTree extends ComponentsTree {
     public static final String IGNORE_RULE_TOOL_TIP = "Creating Ignore Rules is only available when a JFrog Project or Watch is defined.";
     private static final String SHOW_IN_PROJECT_DESCRIPTOR = "Show direct dependency in project descriptor";
     private static final String NO_ISSUES = "Your project was scanned and we didn't find any security issues.";
-    private static final String ERROR_WHILE_SCANNING = "An error occurred while your project was scanned. Please see the Notifications log for more details.";
+    private static final String ERROR_WHILE_SCANNING = "An error occurred while your project was scanned. Please see the Notifications tab for more details.";
 
     private static final String SCANNING = "Scanning...";
     private static final long EXPIRED_CACHE_TIME = TimeUnit.DAYS.toMillis(7); // week
@@ -243,5 +243,4 @@ public class LocalComponentsTree extends ComponentsTree {
     public void setScanErrorEmptyText() {
         getEmptyText().setText(ERROR_WHILE_SCANNING);
     }
-
 }

--- a/src/main/java/com/jfrog/ide/idea/utils/Utils.java
+++ b/src/main/java/com/jfrog/ide/idea/utils/Utils.java
@@ -70,7 +70,7 @@ public class Utils {
         UsageReporter usageReporter = new UsageReporter(PRODUCT_ID + pluginVersion, featureIdArray);
         try {
             usageReporter.reportUsage(serverConfig.getArtifactoryUrl(), serverConfig.getUsername(), serverConfig.getPassword(), serverConfig.getAccessToken(), null, log);
-        } catch (IOException e) {
+        } catch (IOException | RuntimeException e) {
             log.debug("Usage report failed: " + ExceptionUtils.getRootCauseMessage(e));
         }
         log.debug("Usage report sent successfully.");


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
Depends on: https://github.com/jfrog/ide-plugins-common/pull/114
![Screenshot 2023-03-30 at 16 34 20](https://user-images.githubusercontent.com/24526180/228853384-e1a43fe8-291e-44ec-95f2-9b6ac57d7798.png)
