### PR TITLE
Fix Maven/Python ScanLogic Null Pointer Exception

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/scan/ScannerFactory.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ScannerFactory.java
@@ -99,6 +99,7 @@ public class ScannerFactory {
         if (scanner != null) {
             // Set the new executor on the old scan manager
             scanner.setExecutor(executor);
+            scanner.setScanLogic(scanLogic);
             newScanners.put(projectHash, scanner);
         } else {
             // Unlike other scanners whereby we create them if the package descriptor exist, MavenScanner is created if
@@ -136,6 +137,7 @@ public class ScannerFactory {
                     scanner = new PypiScanner(project, pythonSdk, executor, scanLogic);
                 }
                 scanner.setExecutor(executor);
+                scanner.setScanLogic(scanLogic);
                 newScanners.put(projectHash, scanner);
             }
         } catch (NoClassDefFoundError noClassDefFoundError) {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
For Maven and Python projects refreshScanner logic was missing a set for a new ScanLogic object. 
an null pointer exception occurred only when trying to scan a project (Maven/Python) with cached scan results.