### PR TITLE
Read webview resources directly from the JAR

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/ui/JFrogLocalToolWindow.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/JFrogLocalToolWindow.java
@@ -34,8 +34,6 @@ import com.jfrog.ide.idea.scan.ScanManager;
 import com.jfrog.ide.idea.ui.utils.ComponentUtils;
 import com.jfrog.ide.idea.ui.webview.WebviewManager;
 import com.jfrog.ide.idea.ui.webview.WebviewObjectConverter;
-import com.jfrog.ide.idea.utils.Utils;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.cef.browser.CefBrowser;
 import org.jetbrains.annotations.NotNull;
@@ -46,8 +44,6 @@ import java.awt.*;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 
 import static com.jfrog.ide.idea.ui.JFrogToolWindow.SCROLL_BAR_SCROLLING_UNITS;
 
@@ -61,7 +57,6 @@ public class JFrogLocalToolWindow extends AbstractJFrogToolWindow {
     private JComponent compTreeView;
     private boolean isInitialized;
     private IssueNode selectedIssue;
-    private Path tempDirPath;
     private WebviewManager webviewManager;
 
     /**
@@ -221,14 +216,10 @@ public class JFrogLocalToolWindow extends AbstractJFrogToolWindow {
     }
 
     private JComponent initVulnerabilityInfoBrowser() throws IOException, URISyntaxException {
-        tempDirPath = Files.createTempDirectory("jfrog-idea-plugin");
-        Utils.extractFromResources("/jfrog-ide-webview", tempDirPath);
-
-        String pageUri = tempDirPath.resolve("index.html").toFile().toURI().toString();
         webviewManager = new WebviewManager();
         Disposer.register(this, webviewManager);
 
-        CefBrowser browser = webviewManager.createBrowser(pageUri, () -> updateIssueOrLicenseInWebview(selectedIssue));
+        CefBrowser browser = webviewManager.createBrowser(() -> updateIssueOrLicenseInWebview(selectedIssue));
         return (JComponent) browser.getUIComponent();
     }
 
@@ -303,16 +294,6 @@ public class JFrogLocalToolWindow extends AbstractJFrogToolWindow {
         }
         super.onConfigurationChange();
         refreshView();
-    }
-
-    @Override
-    public void dispose() {
-        super.dispose();
-        try {
-            FileUtils.deleteDirectory(tempDirPath.toFile());
-        } catch (IOException e) {
-            Logger.getInstance().warn("Temporary directory could not be deleted: " + tempDirPath.toString() + ". Error: " + ExceptionUtils.getRootCauseMessage(e));
-        }
     }
 
     @Override

--- a/src/main/java/com/jfrog/ide/idea/ui/webview/WebviewManager.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/webview/WebviewManager.java
@@ -53,7 +53,11 @@ public class WebviewManager implements Disposable {
         jbCefBrowser.getJBCefClient().addDisplayHandler(new CefDisplayHandlerAdapter() {
             @Override
             public boolean onConsoleMessage(CefBrowser browser, CefSettings.LogSeverity level, String message, String source, int line) {
-                Logger.getInstance().info(String.format("Webview console message: %s - %s", level, message));
+                if (level == CefSettings.LogSeverity.LOGSEVERITY_VERBOSE) {
+                    Logger.getInstance().debug(String.format("Webview console message: %s - %s", level, message));
+                } else {
+                    Logger.getInstance().info(String.format("Webview console message: %s - %s", level, message));
+                }
                 return false;
             }
         }, jbCefBrowser.getCefBrowser());

--- a/src/main/java/com/jfrog/ide/idea/ui/webview/WebviewManager.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/webview/WebviewManager.java
@@ -5,20 +5,26 @@ import com.intellij.openapi.util.Disposer;
 import com.intellij.ui.jcef.JBCefBrowser;
 import com.jfrog.ide.idea.log.Logger;
 import com.jfrog.ide.idea.ui.jcef.message.MessagePacker;
+import org.cef.CefApp;
+import org.cef.CefSettings;
 import org.cef.browser.CefBrowser;
 import org.cef.browser.CefFrame;
+import org.cef.handler.CefDisplayHandlerAdapter;
 import org.cef.handler.CefLoadHandlerAdapter;
 
 public class WebviewManager implements Disposable {
     private JBCefBrowser jbCefBrowser;
     private MessagePacker messagePacker;
 
-    public CefBrowser createBrowser(String pageUri, Runnable onLoadEnd) {
-        jbCefBrowser = new JBCefBrowser(pageUri);
+    public CefBrowser createBrowser(Runnable onLoadEnd) {
+        jbCefBrowser = new JBCefBrowser();
         Disposer.register(this, jbCefBrowser);
+        jbCefBrowser.loadURL("http://jfrog-idea-plugin/index.html");
         CefBrowser cefBrowser = jbCefBrowser.getCefBrowser();
         jbCefBrowser.createImmediately();
         jbCefBrowser.setOpenLinksInExternalBrowser(true);
+        CefApp.getInstance().registerSchemeHandlerFactory("http", "jfrog-idea-plugin", new WebviewSchemeHandlerFactory());
+        streamConsoleMessagesToLog();
         handleLoadEvent(onLoadEnd);
         messagePacker = new MessagePacker(cefBrowser);
         return cefBrowser;
@@ -28,7 +34,7 @@ public class WebviewManager implements Disposable {
         jbCefBrowser.getJBCefClient().addLoadHandler(new CefLoadHandlerAdapter() {
             @Override
             public void onLoadEnd(CefBrowser browser, CefFrame frame, int httpStatusCode) {
-                Logger.getInstance().info("Issue details view loaded successfully.");
+                Logger.getInstance().info("Issue details view loading ended with status code " + httpStatusCode);
                 super.onLoadEnd(browser, frame, httpStatusCode);
                 if (onLoadEnd != null) {
                     onLoadEnd.run();
@@ -39,6 +45,16 @@ public class WebviewManager implements Disposable {
             public void onLoadError(CefBrowser browser, CefFrame frame, ErrorCode errorCode, String errorText, String failedUrl) {
                 super.onLoadError(browser, frame, errorCode, errorText, failedUrl);
                 Logger.getInstance().error("An error occurred while opening the issue details view: " + errorText);
+            }
+        }, jbCefBrowser.getCefBrowser());
+    }
+
+    private void streamConsoleMessagesToLog() {
+        jbCefBrowser.getJBCefClient().addDisplayHandler(new CefDisplayHandlerAdapter() {
+            @Override
+            public boolean onConsoleMessage(CefBrowser browser, CefSettings.LogSeverity level, String message, String source, int line) {
+                Logger.getInstance().info(String.format("Webview console message: %s - %s", level, message));
+                return false;
             }
         }, jbCefBrowser.getCefBrowser());
     }

--- a/src/main/java/com/jfrog/ide/idea/ui/webview/WebviewResourceHandler.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/webview/WebviewResourceHandler.java
@@ -1,0 +1,109 @@
+package com.jfrog.ide.idea.ui.webview;
+
+import com.jfrog.ide.idea.log.Logger;
+import org.cef.callback.CefCallback;
+import org.cef.handler.CefLoadHandler;
+import org.cef.handler.CefResourceHandler;
+import org.cef.misc.IntRef;
+import org.cef.misc.StringRef;
+import org.cef.network.CefRequest;
+import org.cef.network.CefResponse;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLConnection;
+
+/**
+ * We use this handler to read web resources that are saved inside the plugin's JAR.
+ */
+public class WebviewResourceHandler implements CefResourceHandler {
+    private URL currUrl;
+    private URLConnection connection;
+    private InputStream inputStream;
+    private boolean error;
+
+    @Override
+    public boolean processRequest(CefRequest request, CefCallback callback) {
+        String pathToResource = request.getURL().replace("http://jfrog-idea-plugin", "/jfrog-ide-webview");
+        currUrl = WebviewResourceHandler.class.getResource(pathToResource);
+        try {
+            //noinspection DataFlowIssue
+            connection = currUrl.openConnection();
+            if (inputStream != null) {
+                inputStream.close();
+            }
+            inputStream = connection.getInputStream();
+            error = false;
+            callback.Continue();
+            return true;
+        } catch (IOException | NullPointerException e) {
+            Logger.getInstance().error("An error occurred while reading webview resource.", e);
+            error = true;
+            return false;
+        }
+    }
+
+    @Override
+    public void getResponseHeaders(CefResponse response, IntRef responseLength, StringRef redirectUrl) {
+        if (error) {
+            response.setError(CefLoadHandler.ErrorCode.ERR_FAILED);
+            response.setStatus(500);
+            return;
+        }
+        String url = currUrl.toString();
+        String postfix = url.substring(url.lastIndexOf(".") + 1);
+        switch (postfix) {
+            case "css":
+                response.setMimeType("text/css");
+                break;
+            case "js":
+                response.setMimeType("text/javascript");
+                break;
+            case "html":
+                response.setMimeType("text/html");
+                break;
+            default:
+                response.setMimeType(connection.getContentType());
+        }
+        try {
+            responseLength.set(inputStream.available());
+        } catch (IOException e) {
+            Logger.getInstance().error("An error occurred while reading webview resource.", e);
+            inputStream = null;
+            response.setError(CefLoadHandler.ErrorCode.ERR_FAILED);
+            response.setStatus(500);
+            return;
+        }
+        response.setStatus(200);
+    }
+
+    @Override
+    public boolean readResponse(byte[] dataOut, int bytesToRead, IntRef bytesRead, CefCallback callback) {
+        try {
+            int availableSize = inputStream.available();
+            if (availableSize < 1) {
+                inputStream.close();
+                inputStream = null;
+                return false;
+            }
+            int maxBytesToRead = Math.min(availableSize, bytesToRead);
+            bytesRead.set(inputStream.read(dataOut, 0, maxBytesToRead));
+        } catch (IOException e) {
+            Logger.getInstance().error("An error occurred while reading webview resource.", e);
+            inputStream = null;
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void cancel() {
+        try {
+            inputStream.close();
+        } catch (IOException e) {
+            // Do nothing
+        }
+        inputStream = null;
+    }
+}

--- a/src/main/java/com/jfrog/ide/idea/ui/webview/WebviewResourceHandler.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/webview/WebviewResourceHandler.java
@@ -38,7 +38,7 @@ public class WebviewResourceHandler implements CefResourceHandler {
             callback.Continue();
             return true;
         } catch (IOException | NullPointerException e) {
-            Logger.getInstance().error("An error occurred while reading webview resource.", e);
+            Logger.getInstance().error("An error occurred while reading webview resource: " + currUrl.toString(), e);
             error = true;
             return false;
         }

--- a/src/main/java/com/jfrog/ide/idea/ui/webview/WebviewSchemeHandlerFactory.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/webview/WebviewSchemeHandlerFactory.java
@@ -1,0 +1,14 @@
+package com.jfrog.ide.idea.ui.webview;
+
+import org.cef.browser.CefBrowser;
+import org.cef.browser.CefFrame;
+import org.cef.callback.CefSchemeHandlerFactory;
+import org.cef.handler.CefResourceHandler;
+import org.cef.network.CefRequest;
+
+public class WebviewSchemeHandlerFactory implements CefSchemeHandlerFactory {
+    @Override
+    public CefResourceHandler create(CefBrowser browser, CefFrame frame, String schemeName, CefRequest request) {
+        return new WebviewResourceHandler();
+    }
+}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
Read web resources directly from the JAR, without copying them to a temporary directory first.
Stream the browser's console messages to the plugin's logger.