### PR TITLE
Add Gradle's build directory to the default exclusions

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/ui/configuration/ConfigVerificationUtils.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/configuration/ConfigVerificationUtils.java
@@ -21,7 +21,7 @@ public class ConfigVerificationUtils {
     public static final String EXCLUSIONS_SUFFIX = "*";
     public static String EXCLUSIONS_REGEX_PARSER = "^\\*\\*/\\*\\{([^{}]+)}\\*$";
     public static Pattern EXCLUSIONS_REGEX_PATTERN = Pattern.compile(EXCLUSIONS_REGEX_PARSER);
-    public static final String DEFAULT_EXCLUSIONS = EXCLUSIONS_PREFIX + "{.idea,test,node_modules}" + EXCLUSIONS_SUFFIX;
+    public static final String DEFAULT_EXCLUSIONS = EXCLUSIONS_PREFIX + "{.idea,test,node_modules,build}" + EXCLUSIONS_SUFFIX;
 
     /**
      * Validate config project, watches and excluded paths before saving.

--- a/src/main/java/com/jfrog/ide/idea/ui/configuration/JFrogGlobalConfiguration.form
+++ b/src/main/java/com/jfrog/ide/idea/ui/configuration/JFrogGlobalConfiguration.form
@@ -517,7 +517,7 @@
               </grid>
             </constraints>
             <properties>
-              <text value="&quot;**/*{.idea,test,node_modules}*&quot;"/>
+              <text value="&quot;**/*{.idea,test,node_modules,build}*&quot;"/>
               <toolTipText value="Pattern of project paths to exclude from Xray scanning for npm and Go projects."/>
             </properties>
           </component>


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
Added the build directory (created by Gradle) to the list of default directory exclusions.