### PR TITLE
Fix IndexNotReadyException on plugin startup

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/ui/LocalComponentsTree.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/LocalComponentsTree.java
@@ -1,6 +1,7 @@
 package com.jfrog.ide.idea.ui;
 
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.JBMenuItem;
 import com.intellij.pom.Navigatable;
@@ -207,7 +208,7 @@ public class LocalComponentsTree extends ComponentsTree {
         populateTree(root);
 
         // Run inspections after loaded cache
-        ApplicationManager.getApplication().invokeLater(() -> ScanManager.getInstance(project).runInspections(project));
+        DumbService.getInstance(project).runWhenSmart(() -> ScanManager.getInstance(project).runInspections(project));
     }
 
     public boolean isCacheEmpty() {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
Fix IndexNotReadyException when reading cached results. Inspections will be run after indexing is done.