### PR TITLE
Webview - Add DevTools window

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/ui/JfrogContextMenuHandler.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/JfrogContextMenuHandler.java
@@ -1,0 +1,44 @@
+package com.jfrog.ide.idea.ui;
+
+import org.cef.browser.CefBrowser;
+import org.cef.browser.CefFrame;
+import org.cef.callback.CefContextMenuParams;
+import org.cef.callback.CefMenuModel;
+import org.cef.handler.CefContextMenuHandler;
+
+import javax.swing.*;
+import java.awt.*;
+
+public class JfrogContextMenuHandler implements CefContextMenuHandler {
+    private static final int DEV_TOOLS_ID = 1;
+
+    @Override
+    public void onBeforeContextMenu(CefBrowser browser, CefFrame frame, CefContextMenuParams params, CefMenuModel model) {
+        model.clear();
+        model.addItem(DEV_TOOLS_ID, "Inspect");
+    }
+
+    @Override
+    public boolean onContextMenuCommand(CefBrowser browser, CefFrame frame, CefContextMenuParams params, int commandId, int eventFlags) {
+        if (commandId == DEV_TOOLS_ID) {
+            openDevTools(browser);
+            return true;
+        }
+        return false;
+    }
+
+    private void openDevTools(CefBrowser browser) {
+        SwingUtilities.invokeLater(() -> {
+            CefBrowser devToolsBrowser = browser.getDevTools();
+            JFrame frame = new JFrame("DevTools - JFrog IDE Webview");
+            frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+            frame.setSize(800, 600);
+            frame.getContentPane().add(devToolsBrowser.getUIComponent(), BorderLayout.CENTER);
+            frame.setVisible(true);
+        });
+    }
+
+    @Override
+    public void onContextMenuDismissed(CefBrowser browser, CefFrame frame) {
+    }
+}

--- a/src/main/java/com/jfrog/ide/idea/ui/webview/WebviewManager.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/webview/WebviewManager.java
@@ -4,6 +4,7 @@ import com.intellij.openapi.Disposable;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.ui.jcef.JBCefBrowser;
 import com.jfrog.ide.idea.log.Logger;
+import com.jfrog.ide.idea.ui.JfrogContextMenuHandler;
 import com.jfrog.ide.idea.ui.jcef.message.MessagePacker;
 import com.jfrog.ide.idea.ui.jcef.message.MessageType;
 import org.cef.CefApp;
@@ -28,6 +29,7 @@ public class WebviewManager implements Disposable {
         streamConsoleMessagesToLog();
         handleLoadEvent(onLoadEnd);
         messagePacker = new MessagePacker(cefBrowser);
+        jbCefBrowser.getJBCefClient().addContextMenuHandler(new JfrogContextMenuHandler(), jbCefBrowser.getCefBrowser());
         return cefBrowser;
     }
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
This pull request introduces the display of separate DevTools. Users can access the DevTools window by right-clicking on Webview and selecting the 'Inspect' option.

![image](https://github.com/jfrog/jfrog-idea-plugin/assets/9606235/0fe3a8e1-39a4-4091-9b09-7f1f6422eea6)
