### PR TITLE
Use detailed ScannerSearchTarget as description for secrets results

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/scan/SourceCodeScannerManager.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/SourceCodeScannerManager.java
@@ -209,6 +209,7 @@ public class SourceCodeScannerManager {
     private String createReason(JFrogSecurityWarning warning) {
         switch (warning.getReporter()) {
             case IAC:
+            case SECRETS:
                 return warning.getScannerSearchTarget();
             default:
                 return warning.getReason();


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
This PR introduces the use of the detailed output of the secrets scanner rule explanation as the result descriptor (same as in IaC).
![Screenshot 2023-07-17 at 17 56 07](https://github.com/jfrog/jfrog-idea-plugin/assets/24526180/3be5f7a3-2bd9-4750-a653-dd5117d8c4d0)
