### PR TITLE
Limit Impact Graph size

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ import java.net.http.HttpResponse
 import java.nio.file.Paths
 
 plugins {
-    id "org.jetbrains.intellij" version "1.14.2"
+    id "org.jetbrains.intellij" version "1.15.0"
     id "java"
     id "maven-publish"
     id "de.undercouch.download" version "5.3.0"
@@ -56,7 +56,11 @@ dependencies {
     implementation group: 'com.jfrog.xray.client', name: 'xray-client-java', version: '0.14.1'
     implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
     implementation group: 'org.jfrog.filespecs', name: 'file-specs-java', version: '1.1.2'
-    implementation group: 'com.jfrog.ide', name: 'ide-plugins-common', version: '2.2.1'
+    implementation('com.jfrog.ide:ide-plugins-common') {
+        version {
+            branch = 'limit-impact-tree-size'
+        }
+    }
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.11'
     implementation group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'
     testImplementation group: 'org.mockito', name: 'mockito-inline', version: '4.2.0'

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,4 +7,10 @@ pluginManagement {
     }
 }
 
+sourceControl {
+    gitRepository("https://github.com/asafgabai/ide-plugins-common.git") {
+        producesModule("com.jfrog.ide:ide-plugins-common")
+    }
+}
+
 rootProject.name = 'jfrog-idea-plugin'

--- a/src/main/java/com/jfrog/ide/idea/inspections/AbstractInspection.java
+++ b/src/main/java/com/jfrog/ide/idea/inspections/AbstractInspection.java
@@ -17,7 +17,7 @@ import com.jfrog.ide.common.nodes.DependencyNode;
 import com.jfrog.ide.common.nodes.DescriptorFileTreeNode;
 import com.jfrog.ide.common.nodes.SortableChildrenTreeNode;
 import com.jfrog.ide.common.nodes.VulnerabilityNode;
-import com.jfrog.ide.common.nodes.subentities.ImpactTreeNode;
+import com.jfrog.ide.common.nodes.subentities.ImpactTree;
 import com.jfrog.ide.idea.inspections.upgradeversion.UpgradeVersion;
 import com.jfrog.ide.idea.navigation.NavigationService;
 import com.jfrog.ide.idea.scan.ScannerBase;
@@ -233,8 +233,8 @@ public abstract class AbstractInspection extends LocalInspectionTool implements 
      */
     boolean isNodeMatch(DependencyNode node, String componentName) {
         String artifactID = node.getComponentIdWithoutPrefix();
-        ImpactTreeNode impactPath = node.getImpactPaths();
-        return StringUtils.equals(artifactID, componentName) || impactPath.contains(componentName);
+        ImpactTree impactTree = node.getImpactTree();
+        return StringUtils.equals(artifactID, componentName) || impactTree.contains(componentName);
     }
 
     abstract UpgradeVersion getUpgradeVersion(String componentName, String fixVersion, Collection<String> issues, String descriptorPath);

--- a/src/main/java/com/jfrog/ide/idea/scan/ScannerBase.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ScannerBase.java
@@ -24,6 +24,7 @@ import com.jfrog.ide.common.log.ProgressIndicator;
 import com.jfrog.ide.common.nodes.DependencyNode;
 import com.jfrog.ide.common.nodes.DescriptorFileTreeNode;
 import com.jfrog.ide.common.nodes.FileTreeNode;
+import com.jfrog.ide.common.nodes.subentities.ImpactTree;
 import com.jfrog.ide.common.nodes.subentities.ImpactTreeNode;
 import com.jfrog.ide.common.scan.ComponentPrefix;
 import com.jfrog.ide.common.scan.ScanLogic;
@@ -58,6 +59,8 @@ import static com.jfrog.ide.common.log.Utils.logError;
  * Created by romang on 4/26/17.
  */
 public abstract class ScannerBase {
+    public static final int IMPACT_PATHS_LIMIT = 10;
+
     private final ServerConfig serverConfig;
     private final ComponentPrefix prefix;
     private final Log log;
@@ -244,10 +247,15 @@ public abstract class ScannerBase {
     }
 
     private void addImpactPathToDependencyNode(DependencyNode dependencyNode, List<String> path) {
-        if (dependencyNode.getImpactPaths() == null) {
-            dependencyNode.setImpactPaths(new ImpactTreeNode(path.get(0)));
+        if (dependencyNode.getImpactTree() == null) {
+            dependencyNode.setImpactTree(new ImpactTree(new ImpactTreeNode(path.get(0))));
         }
-        ImpactTreeNode parentImpactTreeNode = dependencyNode.getImpactPaths();
+        ImpactTree impactTree = dependencyNode.getImpactTree();
+        impactTree.incImpactPathsCount();
+        if (impactTree.getImpactPathsCount() > IMPACT_PATHS_LIMIT) {
+            return;
+        }
+        ImpactTreeNode parentImpactTreeNode = impactTree.getRoot();
         for (int pathNodeIndex = 1; pathNodeIndex < path.size(); pathNodeIndex++) {
             String currPathNode = path.get(pathNodeIndex);
             // Find a child of parentImpactTreeNode with a name equals to currPathNode

--- a/src/main/java/com/jfrog/ide/idea/scan/ScannerBase.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ScannerBase.java
@@ -38,6 +38,7 @@ import com.jfrog.ide.idea.ui.LocalComponentsTree;
 import com.jfrog.ide.idea.ui.menus.filtermanager.ConsistentFilterManager;
 import com.jfrog.ide.idea.utils.Utils;
 import com.jfrog.xray.client.services.summary.Components;
+import lombok.Getter;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -63,6 +64,7 @@ public abstract class ScannerBase {
 
     private final ServerConfig serverConfig;
     private final ComponentPrefix prefix;
+    @Getter
     private final Log log;
     // Lock to prevent multiple simultaneous scans
     private final AtomicBoolean scanInProgress = new AtomicBoolean(false);
@@ -416,9 +418,5 @@ public abstract class ScannerBase {
 
     public String getProjectPath() {
         return this.basePath;
-    }
-
-    public Log getLog() {
-        return log;
     }
 }

--- a/src/main/java/com/jfrog/ide/idea/ui/webview/model/ImpactGraph.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/webview/model/ImpactGraph.java
@@ -1,21 +1,28 @@
 package com.jfrog.ide.idea.ui.webview.model;
 
 public class ImpactGraph {
-    private final String name;
-    private final ImpactGraph[] children;
+    private final ImpactGraphNode root;
+    private final int pathsCount;
+    private final int pathsLimit;
 
-    public ImpactGraph(String name, ImpactGraph[] children) {
-        this.name = name;
-        this.children = children;
+    public ImpactGraph(ImpactGraphNode root, int pathsCount, int pathsLimit) {
+        this.root = root;
+        this.pathsCount = pathsCount;
+        this.pathsLimit = pathsLimit;
     }
 
     @SuppressWarnings("unused")
-    public String getName() {
-        return name;
+    public ImpactGraphNode getRoot() {
+        return root;
     }
 
     @SuppressWarnings("unused")
-    public ImpactGraph[] getChildren() {
-        return children;
+    public int getPathsCount() {
+        return pathsCount;
+    }
+
+    @SuppressWarnings("unused")
+    public int getPathsLimit() {
+        return pathsLimit;
     }
 }

--- a/src/main/java/com/jfrog/ide/idea/ui/webview/model/ImpactGraphNode.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/webview/model/ImpactGraphNode.java
@@ -1,0 +1,21 @@
+package com.jfrog.ide.idea.ui.webview.model;
+
+public class ImpactGraphNode {
+    private final String name;
+    private final ImpactGraphNode[] children;
+
+    public ImpactGraphNode(String name, ImpactGraphNode[] children) {
+        this.name = name;
+        this.children = children;
+    }
+
+    @SuppressWarnings("unused")
+    public String getName() {
+        return name;
+    }
+
+    @SuppressWarnings("unused")
+    public ImpactGraphNode[] getChildren() {
+        return children;
+    }
+}


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
Limit the Impact Graph size to up to 10 paths, to avoid high memory consumption and improve readability.