### PR TITLE
Show floating toolbar when results don't match source code

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/actions/StartLocalScanAction.java
+++ b/src/main/java/com/jfrog/ide/idea/actions/StartLocalScanAction.java
@@ -3,10 +3,7 @@ package com.jfrog.ide.idea.actions;
 import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
-import com.intellij.util.messages.MessageBus;
-import com.jfrog.ide.idea.events.ApplicationEvents;
 import com.jfrog.ide.idea.scan.ScanManager;
 import org.jetbrains.annotations.NotNull;
 
@@ -25,8 +22,6 @@ public class StartLocalScanAction extends AnAction {
         if (project == null) {
             return;
         }
-        MessageBus messageBus = ApplicationManager.getApplication().getMessageBus();
-        messageBus.syncPublisher(ApplicationEvents.ON_SCAN_LOCAL_STARTED).update();
         ScanManager.getInstance(project).startScan();
     }
 

--- a/src/main/java/com/jfrog/ide/idea/actions/StartLocalScanAction.java
+++ b/src/main/java/com/jfrog/ide/idea/actions/StartLocalScanAction.java
@@ -1,8 +1,12 @@
 package com.jfrog.ide.idea.actions;
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
+import com.intellij.util.messages.MessageBus;
+import com.jfrog.ide.idea.events.ApplicationEvents;
 import com.jfrog.ide.idea.scan.ScanManager;
 import org.jetbrains.annotations.NotNull;
 
@@ -10,6 +14,10 @@ import org.jetbrains.annotations.NotNull;
  * Created by romang on 3/6/17.
  */
 public class StartLocalScanAction extends AnAction {
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
+    }
 
     @Override
     public void actionPerformed(AnActionEvent e) {
@@ -17,6 +25,8 @@ public class StartLocalScanAction extends AnAction {
         if (project == null) {
             return;
         }
+        MessageBus messageBus = ApplicationManager.getApplication().getMessageBus();
+        messageBus.syncPublisher(ApplicationEvents.ON_SCAN_LOCAL_STARTED).update();
         ScanManager.getInstance(project).startScan();
     }
 

--- a/src/main/java/com/jfrog/ide/idea/events/AnnotationEvents.java
+++ b/src/main/java/com/jfrog/ide/idea/events/AnnotationEvents.java
@@ -1,0 +1,13 @@
+package com.jfrog.ide.idea.events;
+
+import com.intellij.util.messages.Topic;
+
+public interface AnnotationEvents {
+    // Results expiry
+    Topic<AnnotationEvents> ON_IRRELEVANT_RESULT = Topic.create("Source code changed", AnnotationEvents.class);
+
+    /**
+     * Called when the selected file is modified.
+     */
+    void update(String filePath);
+}

--- a/src/main/java/com/jfrog/ide/idea/inspections/JFrogSecurityAnnotator.java
+++ b/src/main/java/com/jfrog/ide/idea/inspections/JFrogSecurityAnnotator.java
@@ -3,15 +3,18 @@ package com.jfrog.ide.idea.inspections;
 import com.intellij.lang.annotation.AnnotationHolder;
 import com.intellij.lang.annotation.ExternalAnnotator;
 import com.intellij.lang.annotation.HighlightSeverity;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiFile;
+import com.intellij.util.messages.MessageBus;
 import com.jfrog.ide.common.nodes.FileIssueNode;
 import com.jfrog.ide.common.nodes.FileTreeNode;
 import com.jfrog.ide.common.nodes.SortableChildrenTreeNode;
+import com.jfrog.ide.idea.events.AnnotationEvents;
 import com.jfrog.ide.idea.ui.ComponentsTree;
 import com.jfrog.ide.idea.ui.LocalComponentsTree;
 import org.jetbrains.annotations.NotNull;
@@ -84,6 +87,11 @@ public class JFrogSecurityAnnotator extends ExternalAnnotator<PsiFile, List<File
                         .range(range)
                         .gutterIconRenderer(iconRenderer)
                         .create();
+            }
+            // Notify outdated scan result
+            else {
+                MessageBus messageBus = ApplicationManager.getApplication().getMessageBus();
+                messageBus.syncPublisher(AnnotationEvents.ON_IRRELEVANT_RESULT).update(warning.getFilePath());
             }
         });
     }

--- a/src/main/java/com/jfrog/ide/idea/inspections/JFrogSecurityAnnotator.java
+++ b/src/main/java/com/jfrog/ide/idea/inspections/JFrogSecurityAnnotator.java
@@ -3,14 +3,12 @@ package com.jfrog.ide.idea.inspections;
 import com.intellij.lang.annotation.AnnotationHolder;
 import com.intellij.lang.annotation.ExternalAnnotator;
 import com.intellij.lang.annotation.HighlightSeverity;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiFile;
-import com.intellij.util.messages.MessageBus;
 import com.jfrog.ide.common.nodes.FileIssueNode;
 import com.jfrog.ide.common.nodes.FileTreeNode;
 import com.jfrog.ide.common.nodes.SortableChildrenTreeNode;
@@ -90,8 +88,7 @@ public class JFrogSecurityAnnotator extends ExternalAnnotator<PsiFile, List<File
             }
             // Notify outdated scan result
             else {
-                MessageBus messageBus = ApplicationManager.getApplication().getMessageBus();
-                messageBus.syncPublisher(AnnotationEvents.ON_IRRELEVANT_RESULT).update(warning.getFilePath());
+                file.getProject().getMessageBus().syncPublisher(AnnotationEvents.ON_IRRELEVANT_RESULT).update(warning.getFilePath());
             }
         });
     }

--- a/src/main/java/com/jfrog/ide/idea/ui/JFrogFloatingToolbar.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/JFrogFloatingToolbar.java
@@ -3,20 +3,35 @@ package com.jfrog.ide.idea.ui;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.actionSystem.PlatformDataKeys;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.toolbar.floating.AbstractFloatingToolbarProvider;
 import com.intellij.openapi.editor.toolbar.floating.FloatingToolbarComponent;
 import com.intellij.openapi.fileEditor.FileEditor;
 import com.intellij.openapi.project.Project;
+import com.intellij.util.messages.MessageBusConnection;
+import com.jfrog.ide.idea.events.AnnotationEvents;
+import com.jfrog.ide.idea.events.ApplicationEvents;
 import com.jfrog.ide.idea.utils.Descriptor;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * @author yahavi
  **/
-public class JFrogFloatingToolbar extends AbstractFloatingToolbarProvider {
+public class JFrogFloatingToolbar extends AbstractFloatingToolbarProvider implements Disposable {
+    private final MessageBusConnection appBusConnection;
+    private Set<String> changedFiles;
+    private Set<FloatingToolbarComponent> components;
+
 
     public JFrogFloatingToolbar() {
         super("JFrog.Floating");
+        changedFiles = new HashSet<>();
+        components = new HashSet<>();
+        this.appBusConnection = ApplicationManager.getApplication().getMessageBus().connect(this);
+        registerOnChangeHandlers();
     }
 
     @Override
@@ -31,6 +46,13 @@ public class JFrogFloatingToolbar extends AbstractFloatingToolbarProvider {
         if (fileEditor == null || fileEditor.getFile() == null) {
             return;
         }
+        if (changedFiles.contains(fileEditor.getFile().getPath())) {
+            component.scheduleShow();
+            components.add(component);
+            return;
+        } else {
+            component.scheduleHide();
+        }
         Descriptor descriptor = Descriptor.fromFileName(fileEditor.getFile().getName());
         if (descriptor == null) {
             return;
@@ -43,6 +65,28 @@ public class JFrogFloatingToolbar extends AbstractFloatingToolbarProvider {
         LocalComponentsTree localComponentsTree = LocalComponentsTree.getInstance(project);
         if (localComponentsTree.isCacheEmpty() || localComponentsTree.isCacheExpired()) {
             component.scheduleShow();
+            components.add(component);
         }
+    }
+
+    private void registerOnChangeHandlers() {
+        appBusConnection.subscribe(AnnotationEvents.ON_IRRELEVANT_RESULT, (AnnotationEvents) this::updateChangedFiles);
+        appBusConnection.subscribe(ApplicationEvents.ON_SCAN_LOCAL_STARTED, (ApplicationEvents) this::clear);
+    }
+
+    private void clear() {
+        this.changedFiles = new HashSet<>();
+        components.forEach(FloatingToolbarComponent::scheduleHide);
+        components = new HashSet<>();
+    }
+
+    private void updateChangedFiles(String s) {
+        this.changedFiles.add(s);
+    }
+
+    @Override
+    public void dispose() {
+        // Disconnect and release resources from the application bus connection
+        appBusConnection.disconnect();
     }
 }

--- a/src/main/java/com/jfrog/ide/idea/ui/JFrogFloatingToolbar.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/JFrogFloatingToolbar.java
@@ -79,9 +79,9 @@ public class JFrogFloatingToolbar extends AbstractFloatingToolbarProvider implem
         filesToolbarComponents = new HashMap<>();
     }
 
-    private void updateFileChanged(String s) {
-        changedFiles.add(s);
-        FloatingToolbarComponent jfrogToolBar = filesToolbarComponents.get(s);
+    private void updateFileChanged(String filePath) {
+        changedFiles.add(filePath);
+        FloatingToolbarComponent jfrogToolBar = filesToolbarComponents.get(filePath);
         if (jfrogToolBar != null) {
             jfrogToolBar.scheduleShow();
         }


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
When the source code no longer matches the scan results, suggest re-scan by showing our `JFrog floating toolbar`.

![Screenshot 2023-08-15 at 12 59 31](https://github.com/jfrog/jfrog-idea-plugin/assets/24526180/4f10082f-aaaa-4e20-8c0f-7f306153276c)
