### PR TITLE
Fix ConcurrentModificationException in SourceCodeScannerManager

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/scan/ScannerBase.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ScannerBase.java
@@ -49,6 +49,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -180,7 +181,7 @@ public abstract class ScannerBase {
     private List<FileTreeNode> walkDepTree(Map<String, DependencyNode> dependencies, DepTree depTree) {
         Map<String, DescriptorFileTreeNode> descriptorNodes = new HashMap<>();
         visitDepTreeNode(dependencies, depTree, Collections.singletonList(depTree.getRootId()), descriptorNodes, new ArrayList<>(), new HashMap<>());
-        return new ArrayList<>(descriptorNodes.values());
+        return new CopyOnWriteArrayList<>(descriptorNodes.values());
     }
 
     /**


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----

Fix the following issue:
> 2023-08-17 14:04:20,412 [509832340]   WARN - #com.jfrog.ide.idea.log.Logger - Xray scan failed: ConcurrentModificationException: 
java.util.ConcurrentModificationException
	at java.base/java.util.Vector$Itr.checkForComodification(Vector.java:1298)
	at java.base/java.util.Vector$Itr.next(Vector.java:1254)
	at com.jfrog.ide.idea.scan.SourceCodeScannerManager.mapDirectIssuesByCve(SourceCodeScannerManager.java:275)
	at com.jfrog.ide.idea.scan.SourceCodeScannerManager.applicabilityScan(SourceCodeScannerManager.java:69)
	at com.jfrog.ide.idea.scan.ScannerBase.scanAndUpdate(ScannerBase.java:157)
	at com.jfrog.ide.idea.scan.ScannerBase$1.run(ScannerBase.java:295)
	at com.intellij.openapi.progress.impl.CoreProgressManager.startTask(CoreProgressManager.java:428)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.startTask(ProgressManagerImpl.java:115)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcessWithProgressAsynchronously$6(CoreProgressManager.java:478)
	at com.intellij.openapi.progress.impl.ProgressRunner.lambda$submit$4(ProgressRunner.java:251)
	at com.intellij.openapi.progress.ProgressManager.lambda$runProcess$0(ProgressManager.java:71)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcess$2(CoreProgressManager.java:186)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$executeProcessUnderProgress$13(CoreProgressManager.java:604)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:679)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computeUnderProgress(CoreProgressManager.java:635)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:603)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:61)
	at com.intellij.openapi.progress.impl.CoreProgressManager.runProcess(CoreProgressManager.java:173)
	at com.intellij.openapi.progress.ProgressManager.runProcess(ProgressManager.java:71)
	at com.intellij.openapi.progress.impl.ProgressRunner.lambda$submit$5(ProgressRunner.java:251)
	at com.intellij.openapi.progress.impl.ProgressRunner.lambda$launchTask$18(ProgressRunner.java:465)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:702)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:699)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1.run(Executors.java:699)
	at java.base/java.lang.Thread.run(Thread.java:833)