### PR TITLE
Update AnalyzerManager to version 1.2.4.1921744

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/scan/ScanBinaryExecutor.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ScanBinaryExecutor.java
@@ -59,7 +59,7 @@ public abstract class ScanBinaryExecutor {
     private static final int NOT_SUPPORTED = 13;
     private static final Path BINARIES_DIR = HOME_PATH.resolve("dependencies").resolve("jfrog-security");
     private static final String SCANNER_BINARY_NAME = "analyzerManager";
-    private static final String SCANNER_BINARY_VERSION = "1.2.4.1908731";
+    private static final String SCANNER_BINARY_VERSION = "1.2.4.1921744";
     private static final String DEFAULT_BINARY_DOWNLOAD_URL = "xsc-gen-exe-analyzer-manager-local/v1/" + SCANNER_BINARY_VERSION;
     private static final String DOWNLOAD_SCANNER_NAME = "analyzerManager.zip";
     private static final String MINIMAL_XRAY_VERSION_SUPPORTED_FOR_ENTITLEMENT = "3.66.0";


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
The Analyzer Manager has been updated to 1.2.4.1921744, which adds the ability to suppress false positive secrets detection by adding `jfrog-ignore` phrase above the unwanted result line.