### PR TITLE
Fix NPE when reading results from cache 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ dependencies {
     implementation group: 'com.jfrog.xray.client', name: 'xray-client-java', version: '0.14.1'
     implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
     implementation group: 'org.jfrog.filespecs', name: 'file-specs-java', version: '1.1.2'
-    implementation group: 'com.jfrog.ide', name: 'ide-plugins-common', version: '2.2.3'
+    implementation group: 'com.jfrog.ide', name: 'ide-plugins-common', version: '2.2.4'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.11'
     implementation group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'
 


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
  The following Null Pointer Exception  was thrown as a result of changing the FileIssueNode data object without updating the cache version:
   
   ```
com.intellij.diagnostic.PluginException: annotator: com.jfrog.ide.idea.inspections.JFrogSecurityAnnotator@7515b1ba (class com.jfrog.ide.idea.inspections.JFrogSecurityAnnotator) [Plugin: org.jfrog.idea]
	at com.intellij.diagnostic.PluginProblemReporterImpl.createPluginExceptionByClass(PluginProblemReporterImpl.java:23)
	at com.intellij.diagnostic.PluginException.createByClass(PluginException.java:89)
	at com.intellij.codeInsight.daemon.impl.ExternalToolPass.processError(ExternalToolPass.java:251)
	at com.intellij.codeInsight.daemon.impl.ExternalToolPass.doApply(ExternalToolPass.java:227)
	at com.intellij.codeInsight.daemon.impl.ExternalToolPass.doApply(ExternalToolPass.java:216)
	at com.intellij.codeInsight.daemon.impl.ExternalToolPass$1.lambda$run$1(ExternalToolPass.java:168)
	at com.intellij.openapi.application.ReadAction.lambda$run$1(ReadAction.java:64)
	at com.intellij.openapi.application.impl.ApplicationImpl.runReadAction(ApplicationImpl.java:923)
	at com.intellij.openapi.application.ReadAction.compute(ReadAction.java:76)
	at com.intellij.openapi.application.ReadAction.run(ReadAction.java:63)
...
Caused by: java.lang.NullPointerException: Cannot invoke "com.jfrog.ide.common.nodes.subentities.FindingInfo.getRowStart()" because "this.findingInfo" is null
```