### PR TITLE
Migrating GlobalSettings component to a service

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/configuration/GlobalSettings.java
+++ b/src/main/java/com/jfrog/ide/idea/configuration/GlobalSettings.java
@@ -27,6 +27,7 @@ import com.intellij.util.messages.MessageBus;
 import com.intellij.util.xmlb.XmlSerializerUtil;
 import com.jfrog.ide.idea.events.ApplicationEvents;
 import com.jfrog.ide.idea.log.Logger;
+import lombok.Getter;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.jetbrains.annotations.NotNull;
 
@@ -35,6 +36,7 @@ import java.io.IOException;
 /**
  * @author yahavi
  */
+@Getter
 @State(name = "GlobalSettings", storages = {@Storage("jfrogConfig.xml")})
 public final class GlobalSettings implements PersistentStateComponent<GlobalSettings> {
     private ServerConfigImpl serverConfig;
@@ -45,7 +47,7 @@ public final class GlobalSettings implements PersistentStateComponent<GlobalSett
     }
 
     public static GlobalSettings getInstance() {
-        return ApplicationManager.getApplication().getComponent(GlobalSettings.class);
+        return ApplicationManager.getApplication().getService(GlobalSettings.class);
     }
 
     /**
@@ -83,10 +85,6 @@ public final class GlobalSettings implements PersistentStateComponent<GlobalSett
     @Override
     public void noStateLoaded() {
         reloadXrayCredentials();
-    }
-
-    public ServerConfigImpl getServerConfig() {
-        return this.serverConfig;
     }
 
     /**

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -50,18 +50,13 @@
     <depends config-file="with-python.xml" optional="true">com.intellij.modules.python</depends>
     <depends config-file="with-python-ce.xml" optional="true">PythonCore</depends>
 
-    <application-components>
-        <component>
-            <implementation-class>com.jfrog.ide.idea.configuration.GlobalSettings</implementation-class>
-        </component>
-    </application-components>
-
     <extensions defaultExtensionNs="com.intellij">
         <applicationConfigurable id="JFrogGlobal" displayName="JFrog Global Configuration"
                                  instance="com.jfrog.ide.idea.ui.configuration.JFrogGlobalConfiguration"/>
         <projectConfigurable id="JFrogCi" displayName="JFrog CI Integration"
                              instance="com.jfrog.ide.idea.ui.configuration.JFrogProjectConfiguration"/>
         <applicationService serviceImplementation="com.jfrog.ide.idea.log.Logger"/>
+        <applicationService serviceImplementation="com.jfrog.ide.idea.configuration.GlobalSettings"/>
         <projectService serviceImplementation="com.jfrog.ide.idea.ui.menus.filtermanager.CiFilterManager"/>
         <projectService serviceImplementation="com.jfrog.ide.idea.scan.ScanManager"/>
         <projectService serviceImplementation="com.jfrog.ide.idea.ci.CiManager"/>


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
Migrating the GlobalSettings component (which is deprecated) to an application service. This should eliminate the need to restart the IDE after installation or updates.