### PR TITLE
Consider all Python packages as direct dependencies 

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/scan/PypiScanner.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/PypiScanner.java
@@ -86,7 +86,6 @@ public class PypiScanner extends SingleDescriptorScanner {
                     continue;
                 }
                 node.getChildren().add(depId);
-                directDeps.remove(depId);
             }
             nodes.put(compId, node);
         }


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
As a result of the way Python packages are consumed by Python projects, we can't confidently say if a package is a direct dependency of the current project. It was decided that is more accurate to treat all Python dependencies as direct dependencies and include them all in the Contextual Analysis scan.
Please notice that the `Populate each node's children ` section is still needed for the impact graph display:

![Screenshot 2023-08-24 at 18 40 15](https://github.com/jfrog/jfrog-idea-plugin/assets/24526180/ea64d5a4-bd13-4dd6-96d2-3af54ae15424)
