### PR TITLE
Fix EOS CodeFlows Jump to code

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/scan/EosScannerExecutor.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/EosScannerExecutor.java
@@ -26,7 +26,6 @@ public class EosScannerExecutor extends ScanBinaryExecutor {
     private static final boolean RUN_WITH_CONFIG_FILE = false;
     private static final List<PackageManagerType> SUPPORTED_PACKAGE_TYPES = List.of(PackageManagerType.PYPI, PackageManagerType.NPM, PackageManagerType.YARN, PackageManagerType.GRADLE, PackageManagerType.MAVEN);
 
-
     public EosScannerExecutor(Log log, ServerConfig serverConfig) {
         this(log, serverConfig, null, true);
     }

--- a/src/main/java/com/jfrog/ide/idea/ui/webview/WebviewObjectConverter.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/webview/WebviewObjectConverter.java
@@ -66,7 +66,7 @@ public class WebviewObjectConverter {
     }
 
     private static Location[] convertCodeFlowsToLocations(FindingInfo[][] codeFlows) {
-        if (codeFlows.length > 0) {
+        if (codeFlows != null && codeFlows.length > 0) {
             Location[] locations = new Location[codeFlows[0].length];
             for (int i = 0; i < codeFlows[0].length; i++) {
                 FindingInfo codeFlow = codeFlows[0][i];

--- a/src/main/java/com/jfrog/ide/idea/ui/webview/event/tasks/JumpToCodeTask.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/webview/event/tasks/JumpToCodeTask.java
@@ -17,6 +17,6 @@ public class JumpToCodeTask {
     }
 
     public void execute(Location location) {
-        this.jumpToCode.execute(location.getFile(), location.getStartRow(), location.getEndRow(), location.getStartColumn(), location.getEndColumn());
+        this.jumpToCode.execute(location.getFile(), location.getStartRow() - 1, location.getEndRow() - 1, location.getStartColumn() - 1, location.getEndColumn() - 1);
     }
 }


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
When clicking on the ' Analysis steps`(CodeFlows) section on the right pane, it highlights the wrong source code section in the editor. The jump-to-code implementation should consider the difference between the displayed line and col indexes to the file accurate indexes.