### PR TITLE
Reference to our release notes page in the plugin's change notes

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -32,11 +32,7 @@
 
     <change-notes>
         <![CDATA[
-          <li>Added the ability to suppress false positive secrets detection by adding 'jfrog-ignore' phrase above the unwanted result line.</li>
-          <li>Bug fix - Fixed error thrown when Go project has no modules.</li>
-          <li>Bug fix - Fixed ConcurrentModificationException thrown during a scan.</li>
-          <li>Bug fix - Fixed converting file paths in Windows.</li>
-          <li>Bug fix - Fixed errors when scanning projects using Gradle <7.6.</li>
+          For the latest release notes, please visit our <a href="https://github.com/jfrog/jfrog-idea-plugin/releases">Release Notes</a> page.
         ]]>
     </change-notes>
 


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
Change our change notes to have a link to our release notes page, instead of updating it every time.