### PR TITLE
Improve source code scanners logging

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/scan/ScanBinaryExecutor.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ScanBinaryExecutor.java
@@ -161,20 +161,19 @@ public abstract class ScanBinaryExecutor {
             if (commandResults.isOk()) {
                 log.debug(commandResults.getRes());
                 return parseOutputSarif(outputFilePath);
-            } else {
-                switch (commandResults.getExitValue()) {
-                    case USER_NOT_ENTITLED -> {
-                        log.debug("User not entitled for advance security scan");
-                        return List.of();
-                    }
-                    case NOT_SUPPORTED -> {
-                        log.debug(String.format("Scanner %s is not supported in the current Analyzer Manager version.", scanType));
-                        return List.of();
-                    }
-                    default -> {
-                        log.info(commandResults.getRes());
-                        throw new IOException(commandResults.getErr());
-                    }
+            }
+            switch (commandResults.getExitValue()) {
+                case USER_NOT_ENTITLED -> {
+                    log.debug("User not entitled for advance security scan");
+                    return List.of();
+                }
+                case NOT_SUPPORTED -> {
+                    log.debug(String.format("Scanner %s is not supported in the current Analyzer Manager version.", scanType));
+                    return List.of();
+                }
+                default -> {
+                    log.info(commandResults.getRes());
+                    throw new IOException(commandResults.getErr());
                 }
             }
         } finally {


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
The scanner's run logs will now be logged in the IDE log instead of in a dedicated log file.
If an error occurs the log level is `INFO`, otherwise `DEBUG`. 