### PR TITLE
Fix - Scanners Failing to Run on Windows Due to Username Spaces

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ repositories {
     }
 }
 
-def buildInfoVersion = '2.41.4'
+def buildInfoVersion = '2.41.6'
 dependencies {
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.15.2'
     implementation group: 'org.jfrog.buildinfo', name: 'build-info-extractor', version: buildInfoVersion
@@ -57,7 +57,7 @@ dependencies {
     implementation group: 'com.jfrog.xray.client', name: 'xray-client-java', version: '0.14.1'
     implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
     implementation group: 'org.jfrog.filespecs', name: 'file-specs-java', version: '1.1.2'
-    implementation group: 'com.jfrog.ide', name: 'ide-plugins-common', version: '2.2.4'
+    implementation group: 'com.jfrog.ide', name: 'ide-plugins-common', version: '2.2.5'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.11'
     implementation group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'
 


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
In some cases when the Windows user name included spaces, we were not able to run some of our source code scanners. 
This PR introduced the use of the new version of our build-info dependency (2.41.6) which includes a fix for this issue.
