### PR TITLE
Fix compatibility problems in future IntelliJ releases

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -8,6 +8,11 @@ on:
   schedule:
     - cron: '0 6 * * *' # Runs every day at 6:00 AM GMT
 
+# Ensures that only the latest commit is running for each PR at a time.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     if: github.event_name == 'schedule' || github.event_name == 'push' || (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'safe to test'))
@@ -20,6 +25,10 @@ jobs:
           - os: windows-latest
             gradlew_suffix: .bat
     steps:
+      - name: Remove 'safe to test' label
+        uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: "safe to test"
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macOS-latest ]
-        testCommand: [ "verifyPlugin runPluginVerifier test", "pythonTests" ]
+        testCommand: [ "test", "pythonTests" ]
         include:
           - os: windows-latest
             gradlewSuffix: .bat

--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -4,7 +4,7 @@ on: [ push, pull_request ]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: macOS-latest
     name: Compatibility verification
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -1,12 +1,10 @@
-name: Test
+name: "Compatibility verification"
 
 on: [ push, pull_request ]
 
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
     name: Compatibility verification
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -1,0 +1,27 @@
+name: Test
+
+on: [ push, pull_request ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    name: Compatibility verification
+    steps:
+      - uses: actions/checkout@v3
+
+      # Install required tools
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: 7.6
+
+      # Run compatibility verification
+      - name: Compatibility verification
+        run: ./gradlew clean verifyPlugin runPluginVerifier

--- a/build.gradle
+++ b/build.gradle
@@ -32,11 +32,9 @@ runIde {
 
 patchPluginXml {
     sinceBuild = "223.4884.69"
+    // Explicitly setting this to an empty string makes the plugin compatible with all IDE versions up to the latest one.
+    // Removing this line will limit compatibility to IDE versions up to 'sandboxVersion'.
     untilBuild = ""
-}
-
-runPluginVerifier {
-    freeArgs = ["-Dplugin.verifier.cache.dir.max.space=8192"]
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -24,15 +24,15 @@ intellij {
     type = intellijType
     plugins = ['gradle', 'maven', 'Groovy', 'properties', 'java', 'Kotlin', 'org.jetbrains.plugins.go:223.8617.56', "PythonCore:223.8617.56"]
     pluginName = 'JFrog'
-    updateSinceUntilBuild = false
-}
-
-runPluginVerifier {
-    ideVersions = [intellijType + "-" + sandboxVersion]
 }
 
 runIde {
     jvmArgs '-Xmx2G'
+}
+
+patchPluginXml {
+    sinceBuild = "223.4884.69"
+    untilBuild = ""
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ import java.net.http.HttpResponse
 import java.nio.file.Paths
 
 plugins {
-    id "org.jetbrains.intellij" version "1.15.0"
+    id "org.jetbrains.intellij" version "1.16.0"
     id "java"
     id "maven-publish"
     id "de.undercouch.download" version "5.3.0"

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ patchPluginXml {
 }
 
 runPluginVerifier {
-    freeArgs = ["-Dplugin.verifier.cache.dir.max.space=2048"]
+    freeArgs = ["-Dplugin.verifier.cache.dir.max.space=8192"]
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,10 @@ patchPluginXml {
     untilBuild = ""
 }
 
+runPluginVerifier {
+    freeArgs = ["-Dplugin.verifier.cache.dir.max.space=2048"]
+}
+
 repositories {
     mavenLocal()
     mavenCentral()

--- a/src/main/java/com/jfrog/ide/idea/inspections/AnnotationIconRenderer.java
+++ b/src/main/java/com/jfrog/ide/idea/inspections/AnnotationIconRenderer.java
@@ -9,7 +9,7 @@ import com.jfrog.ide.common.nodes.subentities.Severity;
 import com.jfrog.ide.idea.ui.LocalComponentsTree;
 import com.jfrog.ide.idea.ui.utils.IconUtils;
 import com.jfrog.ide.idea.utils.Utils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/src/main/java/com/jfrog/ide/idea/inspections/GradleKotlinInspection.java
+++ b/src/main/java/com/jfrog/ide/idea/inspections/GradleKotlinInspection.java
@@ -7,7 +7,7 @@ import com.intellij.psi.PsiElementVisitor;
 import com.jfrog.ide.idea.inspections.upgradeversion.GradleKotlinUpgradeVersion;
 import com.jfrog.ide.idea.inspections.upgradeversion.UpgradeVersion;
 import com.jfrog.ide.idea.utils.Descriptor;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.kotlin.psi.*;
 

--- a/src/main/java/com/jfrog/ide/idea/scan/ApplicabilityScannerExecutor.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ApplicabilityScannerExecutor.java
@@ -9,7 +9,7 @@ import com.jfrog.ide.idea.inspections.JFrogSecurityWarning;
 import com.jfrog.ide.idea.scan.data.PackageManagerType;
 import com.jfrog.ide.idea.scan.data.ScanConfig;
 import com.jfrog.xray.client.services.entitlements.Feature;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jfrog.build.api.util.Log;
 
 import java.io.IOException;

--- a/src/main/java/com/jfrog/ide/idea/scan/SourceCodeScannerManager.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/SourceCodeScannerManager.java
@@ -21,7 +21,7 @@ import com.jfrog.ide.idea.scan.data.applications.ModuleConfig;
 import com.jfrog.ide.idea.scan.data.applications.ScannerConfig;
 import com.jfrog.ide.idea.ui.LocalComponentsTree;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.jetbrains.annotations.NotNull;
 

--- a/src/main/java/com/jfrog/ide/idea/ui/ComponentIssueDetails.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/ComponentIssueDetails.java
@@ -1,6 +1,6 @@
 package com.jfrog.ide.idea.ui;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jfrog.build.extractor.scan.DependencyTree;
 import org.jfrog.build.extractor.scan.Issue;
 

--- a/src/main/java/com/jfrog/ide/idea/ui/ComponentsTreeCellRenderer.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/ComponentsTreeCellRenderer.java
@@ -7,7 +7,7 @@ import com.intellij.util.ui.UIUtil;
 import com.jfrog.ide.common.nodes.FileTreeNode;
 import com.jfrog.ide.common.nodes.SubtitledTreeNode;
 import com.jfrog.ide.idea.ui.utils.IconUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;

--- a/src/main/java/com/jfrog/ide/idea/ui/JFrogLocalToolWindow.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/JFrogLocalToolWindow.java
@@ -27,7 +27,7 @@ import com.jfrog.ide.idea.scan.ScanManager;
 import com.jfrog.ide.idea.ui.utils.ComponentUtils;
 import com.jfrog.ide.idea.ui.webview.WebviewManager;
 import com.jfrog.ide.idea.ui.webview.WebviewObjectConverter;
-import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;

--- a/src/main/java/com/jfrog/ide/idea/ui/LocalComponentsTree.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/LocalComponentsTree.java
@@ -15,7 +15,7 @@ import com.jfrog.ide.idea.navigation.NavigationTarget;
 import com.jfrog.ide.idea.scan.ScanManager;
 import com.jfrog.ide.idea.ui.menus.ToolbarPopupMenu;
 import com.jfrog.ide.idea.utils.Utils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;

--- a/src/main/java/com/jfrog/ide/idea/ui/configuration/ConfigVerificationUtils.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/configuration/ConfigVerificationUtils.java
@@ -2,7 +2,7 @@ package com.jfrog.ide.idea.ui.configuration;
 
 import com.intellij.openapi.options.ConfigurationException;
 import com.jfrog.ide.common.configuration.ServerConfig;
-import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.nio.file.FileSystems;

--- a/src/main/java/com/jfrog/ide/idea/ui/menus/filtermenu/FilterMenu.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/menus/filtermenu/FilterMenu.java
@@ -9,7 +9,7 @@ import com.jfrog.ide.idea.ui.menus.SelectAllCheckbox;
 import com.jfrog.ide.idea.ui.menus.SelectionCheckbox;
 import com.jfrog.ide.idea.ui.menus.ToolbarPopupMenu;
 import org.apache.commons.compress.utils.Lists;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;

--- a/src/main/java/com/jfrog/ide/idea/utils/Descriptor.java
+++ b/src/main/java/com/jfrog/ide/idea/utils/Descriptor.java
@@ -1,6 +1,6 @@
 package com.jfrog.ide.idea.utils;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Represents all supported file descriptor types.

--- a/src/main/java/com/jfrog/ide/idea/utils/Utils.java
+++ b/src/main/java/com/jfrog/ide/idea/utils/Utils.java
@@ -12,7 +12,7 @@ import com.jfrog.ide.idea.configuration.GlobalSettings;
 import com.jfrog.ide.idea.configuration.ServerConfigImpl;
 import com.jfrog.ide.idea.log.Logger;
 import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.jfrog.build.extractor.scan.DependencyTree;

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -36,7 +36,6 @@
         ]]>
     </change-notes>
 
-    <idea-version since-build="223.4884.69"/>
     <depends>com.intellij.modules.lang</depends>
     <depends config-file="with-gradle.xml" optional="true">com.intellij.gradle</depends>
     <depends config-file="with-groovy.xml" optional="true">org.intellij.groovy</depends>

--- a/src/test/java/com/jfrog/ide/idea/integration/IACScannerIntegrationTests.java
+++ b/src/test/java/com/jfrog/ide/idea/integration/IACScannerIntegrationTests.java
@@ -5,7 +5,7 @@ import com.jfrog.ide.idea.inspections.JFrogSecurityWarning;
 import com.jfrog.ide.idea.log.Logger;
 import com.jfrog.ide.idea.scan.IACScannerExecutor;
 import com.jfrog.ide.idea.scan.data.ScanConfig;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.util.List;

--- a/src/test/java/com/jfrog/ide/idea/integration/SecretsScannerIntegrationTests.java
+++ b/src/test/java/com/jfrog/ide/idea/integration/SecretsScannerIntegrationTests.java
@@ -5,7 +5,7 @@ import com.jfrog.ide.idea.inspections.JFrogSecurityWarning;
 import com.jfrog.ide.idea.log.Logger;
 import com.jfrog.ide.idea.scan.SecretsScannerExecutor;
 import com.jfrog.ide.idea.scan.data.ScanConfig;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.util.List;


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
Use the Apache Commons Lang dependency directly, instead of calling the one used by IntelliJ (it's already directly imported, but was used only in part of its usages).
