### PR TITLE
Scan all available roots when no configuration file can be found by JAS scanners & remove JAS timeout

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/scan/ScanManager.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ScanManager.java
@@ -31,13 +31,11 @@ import static com.jfrog.ide.common.log.Utils.logError;
 import static com.jfrog.ide.common.utils.XrayConnectionUtils.createXrayClientBuilder;
 
 public class ScanManager {
-    private final int SCAN_TIMEOUT_MINUTES = 60;
     private final Project project;
     private final ScannerFactory factory;
     private final SourceCodeScannerManager sourceCodeScannerManager;
     private Map<Integer, ScannerBase> scanners = Maps.newHashMap();
     private ExecutorService executor;
-
 
     private ScanManager(@NotNull Project project) {
         this.project = project;
@@ -97,8 +95,8 @@ public class ScanManager {
                     scanner.asyncScanAndUpdateResults();
                 }
                 executor.shutdown();
-                if (!executor.awaitTermination(SCAN_TIMEOUT_MINUTES, TimeUnit.MINUTES)) {
-                    logError(Logger.getInstance(), "Scan timeout of " + SCAN_TIMEOUT_MINUTES + " minutes elapsed. The scan is being canceled.", true);
+                if (!executor.awaitTermination(Long.MAX_VALUE, TimeUnit.MINUTES)) {
+                    logError(Logger.getInstance(), "Scan timeout elapsed. The scan is being canceled.", true);
                 }
                 // Cache tree only if no errors occurred during scan.
                 if (scanners.values().stream().anyMatch(ScannerBase::isScanErrorOccurred)) {

--- a/src/main/java/com/jfrog/ide/idea/scan/ScanUtils.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ScanUtils.java
@@ -12,8 +12,6 @@ import org.apache.commons.lang3.SystemUtils;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collection;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -28,7 +26,7 @@ public class ScanUtils {
      * @param project     - the project
      * @return local scan paths
      */
-    static Set<Path> createScanPaths(Map<Integer, ScannerBase> scannersMap, Project project) {
+    public static Set<Path> createScanPaths(Project project) {
         final Set<Path> paths = Sets.newHashSet();
         paths.add(com.jfrog.ide.idea.utils.Utils.getProjectBasePath(project));
         for (Module module : ModuleManager.getInstance(project).getModules()) {
@@ -37,7 +35,6 @@ public class ScanUtils {
                 paths.add(modulePath.toNioPath());
             }
         }
-        scannersMap.values().stream().map(ScannerBase::getProjectPaths).flatMap(Collection::stream).forEach(paths::add);
         Logger.getInstance().debug("Scanning projects in the following paths: " + paths);
         return paths;
     }

--- a/src/main/java/com/jfrog/ide/idea/scan/ScannerFactory.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ScannerFactory.java
@@ -15,6 +15,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -45,7 +46,8 @@ public class ScannerFactory {
         Map<Integer, ScannerBase> scanners = Maps.newHashMap();
         refreshMavenScanner(scanners, oldScanners, executor, scanLogic);
         refreshPypiScanners(scanners, oldScanners, executor, scanLogic);
-        Set<Path> scanPaths = createScanPaths(oldScanners, project);
+        Set<Path> scanPaths = createScanPaths(project);
+        oldScanners.values().stream().map(ScannerBase::getProjectPaths).flatMap(Collection::stream).forEach(scanPaths::add);
         refreshGenericScanners(scanners, oldScanners, scanPaths, executor, scanLogic);
         return scanners;
     }

--- a/src/main/java/com/jfrog/ide/idea/scan/data/applications/JFrogApplicationsConfig.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/data/applications/JFrogApplicationsConfig.java
@@ -6,11 +6,12 @@ import com.jfrog.ide.idea.configuration.GlobalSettings;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import static com.jfrog.ide.idea.scan.SourceCodeScannerManager.convertToSkippedFolders;
-import static com.jfrog.ide.idea.utils.Utils.getProjectBasePath;
 
 @Getter
 @NoArgsConstructor
@@ -22,15 +23,16 @@ public class JFrogApplicationsConfig {
 
     public static JFrogApplicationsConfig createApplicationConfigWithDefaultModule(Project project) {
         JFrogApplicationsConfig applicationsConfig = new JFrogApplicationsConfig();
-
-        ModuleConfig defualtModuleConfig = new ModuleConfig();
-        defualtModuleConfig.setSourceRoot(getProjectBasePath(project).toAbsolutePath().toString());
-        defualtModuleConfig.setExcludePatterns(convertToSkippedFolders(GlobalSettings.getInstance().getServerConfig().getExcludedPaths()));
-
+        Set<Path> paths = com.jfrog.ide.idea.scan.ScanUtils.createScanPaths(project);
         applicationsConfig.modules = new ArrayList<>();
-        applicationsConfig.modules.add(defualtModuleConfig);
+
+        for (Path path : paths) {
+            ModuleConfig defualtModuleConfig = new ModuleConfig();
+            defualtModuleConfig.setSourceRoot(path.toString());
+            defualtModuleConfig.setExcludePatterns(convertToSkippedFolders(GlobalSettings.getInstance().getServerConfig().getExcludedPaths()));
+            applicationsConfig.modules.add(defualtModuleConfig);
+        }
 
         return applicationsConfig;
     }
-
 }


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
This pull request resolves an issue in the JAS scanners. Previously, in the absence of a configuration file, the scanners would only scan the root project of the opened workspace. This fix ensures that when no configuration is available, the scanners will now comprehensively scan all roots detected by IDEA.

Additionally, this PR removes the timeout restriction for all JAS scanners.