### PR TITLE
Pin Python version to 3.11.5 for GHA YAML

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
           check-latest: true
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.11.5'
       # Install JFrog CLI for ConnectionDetailsFromCliTest
       - name: Install JFrog CLI
         run: curl -fL https://install-cli.jfrog.io | sh


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
We pin the python version rather than using the latest version, since python 3.12.0 fails to pip install tests dependencies.