### PR TITLE
Fix running executables with spaces in their paths in Windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ repositories {
     }
 }
 
-def buildInfoVersion = '2.41.9'
+def buildInfoVersion = '2.41.13'
 def idePluginsCommonVersion = '2.3.5'
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ repositories {
 }
 
 def buildInfoVersion = '2.41.13'
-def idePluginsCommonVersion = '2.3.5'
+def idePluginsCommonVersion = '2.3.6'
 
 dependencies {
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.15.2'


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----

Update build-info version to 2.41.13

JAS scanners are not running on Windows machines where the user name has space in there name.
Updating build-info version to apply the fix for this issue: https://github.com/jfrog/build-info/pull/777