### PR TITLE
Override a deprecated func to prevent unnecessary errors

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/actions/ScanTimeLabelAction.java
+++ b/src/main/java/com/jfrog/ide/idea/actions/ScanTimeLabelAction.java
@@ -1,6 +1,7 @@
 package com.jfrog.ide.idea.actions;
 
 import com.intellij.icons.AllIcons;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.Presentation;
 import com.intellij.openapi.actionSystem.ex.ToolbarLabelAction;
@@ -16,6 +17,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
 
 public class ScanTimeLabelAction extends ToolbarLabelAction {
+
     @Override
     public void update(@NotNull AnActionEvent e) {
         super.update(e);
@@ -37,5 +39,11 @@ public class ScanTimeLabelAction extends ToolbarLabelAction {
             presentation.setText("");
             presentation.setIcon(null);
         }
+    }
+
+    @NotNull
+    @Override
+    public ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.EDT;
     }
 }


### PR DESCRIPTION
- [X] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
The ActionUpdateThread has a deprecated func called getActionUpdateThread.
We override it so we wont use the deprecated func that pops errors for all our users.
Is this case, the function should return `EDT`(Event Dispatch Thread) , as the current process affects the ui text. 
This is not needed in other places in the code as it is already being override in all places.
