### PR TITLE
Configured the verify plugin command 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,23 @@ patchPluginXml {
     untilBuild = ""
 }
 
+listProductsReleases {
+    doLast {
+        // At the end of the build, write the first and last versions of the products to the output file.
+        // This will be used by the runPluginVerifier task to validate the compatibility of the plugin against the
+        // first and last versions of IntelliJ IDEA.
+        def outputFileObj = outputFile.get().asFile
+        if (outputFileObj.exists()) {
+            def lines = outputFileObj.readLines()
+            if (!lines.isEmpty()) {
+                def firstVersion = lines.first()
+                def lastVersion = lines.last()
+                outputFileObj.write("$firstVersion\n$lastVersion")
+            }
+        }
+    }
+}
+
 repositories {
     mavenLocal()
     mavenCentral()


### PR DESCRIPTION
- [X] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----

This PR updates the config in the build gradle for verify plugin command.
Instead of checking the plugin on every version of IDEA, and running up the runner space, it now checks only on the oldest(as described in the project) and newest versions of IDEA.