### PR TITLE
Rule id is shown in warning title

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/scan/SastScannerExecutor.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/SastScannerExecutor.java
@@ -46,9 +46,9 @@ public class SastScannerExecutor extends ScanBinaryExecutor {
                 results.put(warning.getFilePath(), fileNode);
             }
 
-            FileIssueNode issueNode = new SastIssueNode(warning.getRuleID(),
+            FileIssueNode issueNode = new SastIssueNode(warning.getReason(),
                     warning.getFilePath(), warning.getLineStart(), warning.getColStart(), warning.getLineEnd(), warning.getColEnd(),
-                    warning.getScannerSearchTarget(), warning.getLineSnippet(), warning.getCodeFlows(), warning.getSeverity(), warning.getRuleID());
+                    warning.getReason(), warning.getLineSnippet(), warning.getCodeFlows(), warning.getSeverity(), warning.getRuleID());
             fileNode.addIssue(issueNode);
         }
         return new ArrayList<>(results.values());

--- a/src/main/java/com/jfrog/ide/idea/ui/webview/WebviewObjectConverter.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/webview/WebviewObjectConverter.java
@@ -52,10 +52,10 @@ public class WebviewObjectConverter {
 
     public static IssuePage convertFileIssueToIssuePage(FileIssueNode fileIssueNodeNode) {
         return new IssuePage()
+                .header(fileIssueNodeNode.getReason())
                 .type(ConvertPageType(fileIssueNodeNode.getReporterType()))
                 .severity(fileIssueNodeNode.getSeverity().name())
                 .description(fileIssueNodeNode.getReason())
-                .header(fileIssueNodeNode.getTitle())
                 .location(convertFileLocation(fileIssueNodeNode));
     }
 


### PR DESCRIPTION
- [X] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
I switched the title of SAST warnings to the `reason` instead of `ruleId`