### PR TITLE
Changed the SAST title to the short description rule

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/inspections/JFrogSecurityWarning.java
+++ b/src/main/java/com/jfrog/ide/idea/inspections/JFrogSecurityWarning.java
@@ -57,23 +57,23 @@ public class JFrogSecurityWarning {
                 getFirstRegion(result).getStartColumn() - 1,
                 getFirstRegion(result).getEndLine() - 1,
                 getFirstRegion(result).getEndColumn() - 1,
-                result.getMessage().getText(),
+                determineReason(result.getMessage().getText(), rule.getShortDescription().getText(), reporter),
                 getFilePath(result),
                 result.getRuleId(),
                 getFirstRegion(result).getSnippet().getText(),
                 reporter,
-                isWarningApplicable(result,rule),
+                isWarningApplicable(result, rule),
                 Severity.fromSarif(result.getSeverity()),
                 convertCodeFlowsToFindingInfo(result.getCodeFlows())
         );
     }
 
-    private static boolean isWarningApplicable(SarifResult result,Rule rule){
-       return !result.getKind().equals("pass") && (rule.getRuleProperties().map(properties -> properties.getApplicability().equals("applicable")).orElse(true));
+    private static boolean isWarningApplicable(SarifResult result, Rule rule) {
+        return !result.getKind().equals("pass") && (rule.getRuleProperties().map(properties -> properties.getApplicability().equals("applicable")).orElse(true));
     }
 
-    private static String getFilePath(SarifResult result){
-       return !result.getLocations().isEmpty() ? uriToPath(result.getLocations().get(0).getPhysicalLocation().getArtifactLocation().getUri()) : "";
+    private static String getFilePath(SarifResult result) {
+        return !result.getLocations().isEmpty() ? uriToPath(result.getLocations().get(0).getPhysicalLocation().getArtifactLocation().getUri()) : "";
     }
 
     private static FindingInfo[][] convertCodeFlowsToFindingInfo(List<CodeFlow> codeFlows) {
@@ -120,6 +120,10 @@ public class JFrogSecurityWarning {
 
     private static String uriToPath(String path) {
         return Paths.get(URI.create(path)).toString();
+    }
+
+    private static String determineReason(String resultMessage, String ruleMessage, SourceCodeScanType scannerType) {
+        return scannerType.equals(SourceCodeScanType.SAST) ? ruleMessage : resultMessage;
     }
 }
 


### PR DESCRIPTION
- [X] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
Created a function to determine the reason according to scanner type, as when the scan is of SAST, we take the short description 