### PR TITLE
Project declaration itself triggers a violation from xray

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/scan/MavenScanner.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/MavenScanner.java
@@ -186,7 +186,12 @@ public class MavenScanner extends ScannerBase {
                 // Each dependency might be a child of more than one POM file, but Artifact is a tree node, so it can have only one parent.
                 // The solution for this is to clone the dependency before adding it as a child of the POM.
                 DependencyNode clonedDep = (DependencyNode) dependencyNode.clone();
-                clonedDep.setIndirect(!parents.get(vulnerableDepId).contains(descriptorId));
+                if (vulnerableDepId.equals(descriptorId)) {
+                    clonedDep.setIndirect(false);
+                }
+                else {
+                    clonedDep.setIndirect(!parents.get(vulnerableDepId).contains(descriptorId));
+                }
                 descriptorMap.get(descriptorPath).addDependency(clonedDep);
             }
         }

--- a/src/main/java/com/jfrog/ide/idea/scan/MavenScanner.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/MavenScanner.java
@@ -186,12 +186,7 @@ public class MavenScanner extends ScannerBase {
                 // Each dependency might be a child of more than one POM file, but Artifact is a tree node, so it can have only one parent.
                 // The solution for this is to clone the dependency before adding it as a child of the POM.
                 DependencyNode clonedDep = (DependencyNode) dependencyNode.clone();
-                if (vulnerableDepId.equals(descriptorId)) {
-                    clonedDep.setIndirect(false);
-                }
-                else {
-                    clonedDep.setIndirect(!parents.get(vulnerableDepId).contains(descriptorId));
-                }
+                clonedDep.setIndirect(!vulnerableDepId.equals(descriptorId) && !parents.get(vulnerableDepId).contains(descriptorId));
                 descriptorMap.get(descriptorPath).addDependency(clonedDep);
             }
         }

--- a/src/main/java/com/jfrog/ide/idea/scan/SingleDescriptorScanner.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/SingleDescriptorScanner.java
@@ -62,11 +62,16 @@ public abstract class SingleDescriptorScanner extends ScannerBase {
         DescriptorFileTreeNode fileTreeNode = new DescriptorFileTreeNode(descriptorFilePath);
         for (DependencyNode dependency : depScanResults) {
             boolean directDep = false;
-            for (String parentId : parents.get(dependency.getComponentIdWithoutPrefix())) {
-                DepTreeNode parent = depTree.nodes().get(parentId);
-                if (descriptorFilePath.equals(parent.getDescriptorFilePath())) {
-                    directDep = true;
-                    break;
+            if(dependency.getComponentIdWithoutPrefix().equals(depTree.rootId())) {
+                directDep = true;
+            }
+            else {
+                for (String parentId : parents.get(dependency.getComponentIdWithoutPrefix())) {
+                    DepTreeNode parent = depTree.nodes().get(parentId);
+                    if (descriptorFilePath.equals(parent.getDescriptorFilePath())) {
+                        directDep = true;
+                        break;
+                    }
                 }
             }
             dependency.setIndirect(!directDep);


### PR DESCRIPTION
- [X] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
Added handeling for cases where the project itself is a violation (for example rule on licenses that the project itself violates),
now when we group to descriptors, we check if the vulnerable dependency is part of the root of the descriptor.
if so, we add it appropriately.
