### PR TITLE
Fix Analyzer Manager proxy

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/scan/ScanBinaryExecutor.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ScanBinaryExecutor.java
@@ -67,7 +67,6 @@ public abstract class ScanBinaryExecutor {
     private static final String ENV_PASSWORD = "JF_PASS";
     private static final String ENV_ACCESS_TOKEN = "JF_TOKEN";
     private static final String ENV_HTTP_PROXY = "HTTP_PROXY";
-    private static final String ENV_HTTPS_PROXY = "HTTPS_PROXY";
     private static final String JFROG_RELEASES = "https://releases.jfrog.io/artifactory/";
     private static Path binaryTargetPath;
     private static Path archiveTargetPath;
@@ -329,7 +328,6 @@ public abstract class ScanBinaryExecutor {
                 proxyUrl = proxyConfiguration.username + ":" + proxyConfiguration.password + "@" + proxyUrl;
             }
             env.put(ENV_HTTP_PROXY, "http://" + proxyUrl);
-            env.put(ENV_HTTPS_PROXY, "https://" + proxyUrl);
         }
         return env;
     }

--- a/src/test/java/com/jfrog/ide/idea/scan/PypiScannerTest.java
+++ b/src/test/java/com/jfrog/ide/idea/scan/PypiScannerTest.java
@@ -123,7 +123,6 @@ public class PypiScannerTest extends LightJavaCodeInsightFixtureTestCase {
         assertSize(16, scrappy.getChildren());
 
         // Check transitive dependency
-        System.out.println("Children of scrapy"  + ": " + scrappy.getChildren());
         String pyOpenSSLDepId = scrappy.getChildren().stream().filter(childId -> childId.startsWith(TRANSITIVE_DEPENDENCY_NAME + ":")).findFirst().get();
         DepTreeNode pyOpenSSLDepNode = results.nodes().get(pyOpenSSLDepId);
         assertNotNull("Couldn't find node '" + pyOpenSSLDepId + "'.", pyOpenSSLDepNode);

--- a/src/test/java/com/jfrog/ide/idea/scan/PypiScannerTest.java
+++ b/src/test/java/com/jfrog/ide/idea/scan/PypiScannerTest.java
@@ -123,6 +123,7 @@ public class PypiScannerTest extends LightJavaCodeInsightFixtureTestCase {
         assertSize(16, scrappy.getChildren());
 
         // Check transitive dependency
+        System.out.println("Children of scrapy"  + ": " + scrappy.getChildren());
         String pyOpenSSLDepId = scrappy.getChildren().stream().filter(childId -> childId.startsWith(TRANSITIVE_DEPENDENCY_NAME + ":")).findFirst().get();
         DepTreeNode pyOpenSSLDepNode = results.nodes().get(pyOpenSSLDepId);
         assertNotNull("Couldn't find node '" + pyOpenSSLDepId + "'.", pyOpenSSLDepNode);

--- a/src/test/java/com/jfrog/ide/idea/scan/PypiScannerTest.java
+++ b/src/test/java/com/jfrog/ide/idea/scan/PypiScannerTest.java
@@ -42,7 +42,7 @@ public class PypiScannerTest extends LightJavaCodeInsightFixtureTestCase {
     private static final String SDK_NAME = "Test Python SDK";
     private static final String DIRECT_DEPENDENCY_NAME = "Scrapy";
     private static final String DIRECT_DEPENDENCY_VERSION = "2.9.0";
-    private static final String TRANSITIVE_DEPENDENCY_NAME = "pyOpenSSL";
+    private static final String TRANSITIVE_DEPENDENCY_NAME = "pyopenssl";
 
     private ExecutorService executorService;
     private Sdk pythonSdk;


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----


We only support HTTP proxy for now as JetBrains does not give indication if proxy is HTTP or HTTPS
when moving to CLI, we will create a ping function to determine if proxy is HTTP or HTTPS

Also fixed python test