### PR TITLE
Upgrade com.fasterxml.jackson.core to 2.15.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,7 @@ dependencies {
     implementation group: 'org.jfrog.buildinfo', name: 'build-info-extractor', version: buildInfoVersion
     implementation group: 'com.jfrog.ide', name: 'ide-plugins-common', version: idePluginsCommonVersion
     implementation group: 'org.jfrog.buildinfo', name: 'build-info-client', version: buildInfoVersion
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.15.2'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.15.3'
     implementation group: 'org.jfrog.buildinfo', name: 'build-info-api', version: buildInfoVersion
     implementation group: 'com.jfrog.xray.client', name: 'xray-client-java', version: '0.14.1'
     implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'

--- a/src/main/java/com/jfrog/ide/idea/scan/ScanBinaryExecutor.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ScanBinaryExecutor.java
@@ -67,7 +67,6 @@ public abstract class ScanBinaryExecutor {
     private static final String ENV_PASSWORD = "JF_PASS";
     private static final String ENV_ACCESS_TOKEN = "JF_TOKEN";
     private static final String ENV_HTTP_PROXY = "HTTP_PROXY";
-    private static final String ENV_HTTPS_PROXY = "HTTPS_PROXY";
     private static final String JFROG_RELEASES = "https://releases.jfrog.io/artifactory/";
     private static Path binaryTargetPath;
     private static Path archiveTargetPath;
@@ -328,8 +327,8 @@ public abstract class ScanBinaryExecutor {
             if (StringUtils.isNoneBlank(proxyConfiguration.username, proxyConfiguration.password)) {
                 proxyUrl = proxyConfiguration.username + ":" + proxyConfiguration.password + "@" + proxyUrl;
             }
+            //jfrog-ignore
             env.put(ENV_HTTP_PROXY, "http://" + proxyUrl);
-            env.put(ENV_HTTPS_PROXY, "https://" + proxyUrl);
         }
         return env;
     }

--- a/src/main/java/com/jfrog/ide/idea/scan/ScanBinaryExecutor.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ScanBinaryExecutor.java
@@ -58,7 +58,7 @@ public abstract class ScanBinaryExecutor {
     private static final int USER_NOT_ENTITLED = 31;
     private static final int NOT_SUPPORTED = 13;
     private static final String SCANNER_BINARY_NAME = "analyzerManager";
-    private static final String SCANNER_BINARY_VERSION = "1.15.2";
+    private static final String SCANNER_BINARY_VERSION = "1.20.0";
     private static final String BINARY_DOWNLOAD_URL = "xsc-gen-exe-analyzer-manager-local/v1/" + SCANNER_BINARY_VERSION;
     private static final String DOWNLOAD_SCANNER_NAME = "analyzerManager.zip";
     private static final String MINIMAL_XRAY_VERSION_SUPPORTED_FOR_ENTITLEMENT = "3.66.0";

--- a/src/main/java/com/jfrog/ide/idea/scan/ScanBinaryExecutor.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ScanBinaryExecutor.java
@@ -58,7 +58,7 @@ public abstract class ScanBinaryExecutor {
     private static final int USER_NOT_ENTITLED = 31;
     private static final int NOT_SUPPORTED = 13;
     private static final String SCANNER_BINARY_NAME = "analyzerManager";
-    private static final String SCANNER_BINARY_VERSION = "1.20.0";
+    private static final String SCANNER_BINARY_VERSION = "1.20.1";
     private static final String BINARY_DOWNLOAD_URL = "xsc-gen-exe-analyzer-manager-local/v1/" + SCANNER_BINARY_VERSION;
     private static final String DOWNLOAD_SCANNER_NAME = "analyzerManager.zip";
     private static final String MINIMAL_XRAY_VERSION_SUPPORTED_FOR_ENTITLEMENT = "3.66.0";


### PR DESCRIPTION
- [X] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
Upgrade `com.fasterxml.jackson.core `to `2.15.3`, fix version according to catalog