### PR TITLE
Fix compatibility issue with JfrogContextMenuHandler interface

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/ui/JfrogContextMenuHandler.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/JfrogContextMenuHandler.java
@@ -4,6 +4,7 @@ import org.cef.browser.CefBrowser;
 import org.cef.browser.CefFrame;
 import org.cef.callback.CefContextMenuParams;
 import org.cef.callback.CefMenuModel;
+import org.cef.callback.CefRunContextMenuCallback;
 import org.cef.handler.CefContextMenuHandler;
 
 import javax.swing.*;
@@ -40,5 +41,12 @@ public class JfrogContextMenuHandler implements CefContextMenuHandler {
 
     @Override
     public void onContextMenuDismissed(CefBrowser browser, CefFrame frame) {
+    }
+
+    @Override
+    public boolean runContextMenu(CefBrowser browser, CefFrame frame, CefContextMenuParams params, CefMenuModel model, CefRunContextMenuCallback callback) {
+        // Return false to use the default context menu handling
+        // This maintains the existing behavior while implementing the required method for IntelliJ 2025+
+        return false;
     }
 }


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----
- Added missing implementation for runContextMenu in JfrogContextMenuHandler in order to resolve a compatibility issue with cef api.
