### PR TITLE
Add option to control AM version, fix CA result parsing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,9 +26,8 @@ intellij {
     pluginName = 'JFrog'
 }
 
-//TODO: remove this segment and use latest when the OOM erro is solved https://youtrack.jetbrains.com/issue/MP-7366
 runPluginVerifier {
-    verifierVersion = '1.381'
+    verifierVersion = '1.400'
 }
 
 runIde {

--- a/src/main/java/com/jfrog/ide/idea/configuration/GlobalSettings.java
+++ b/src/main/java/com/jfrog/ide/idea/configuration/GlobalSettings.java
@@ -68,6 +68,7 @@ public final class GlobalSettings implements PersistentStateComponent<GlobalSett
         serverConfig.setConnectionRetries(this.serverConfig.getConnectionRetries());
         serverConfig.setConnectionTimeout(this.serverConfig.getConnectionTimeout());
         serverConfig.setExternalResourcesRepo(this.serverConfig.getExternalResourcesRepo());
+        serverConfig.setScannerBinaryVersion(this.serverConfig.getScannerBinaryVersion());
 
         GlobalSettings settings = new GlobalSettings();
         settings.serverConfig = serverConfig;
@@ -134,6 +135,7 @@ public final class GlobalSettings implements PersistentStateComponent<GlobalSett
         this.serverConfig.setConnectionRetries(serverConfig.getConnectionRetries());
         this.serverConfig.setConnectionTimeout(serverConfig.getConnectionTimeout());
         this.serverConfig.setExternalResourcesRepo(serverConfig.getExternalResourcesRepo());
+        this.serverConfig.setScannerBinaryVersion(serverConfig.getScannerBinaryVersion());
         this.serverConfig.setPolicyType(serverConfig.getPolicyType());
         this.serverConfig.setProject(serverConfig.getProject());
         this.serverConfig.setWatches(serverConfig.getWatches());

--- a/src/main/java/com/jfrog/ide/idea/configuration/ServerConfigImpl.java
+++ b/src/main/java/com/jfrog/ide/idea/configuration/ServerConfigImpl.java
@@ -103,6 +103,8 @@ public class ServerConfigImpl implements ServerConfig {
     private Integer connectionTimeout;
     @Tag
     private String externalResourcesRepo;
+    @Tag
+    private String scannerBinaryVersion;
     // The subsystem key of the plugin configuration in the PasswordSafe
     @Transient
     private String jfrogSettingsCredentialsKey = JFROG_SETTINGS_KEY;
@@ -125,6 +127,7 @@ public class ServerConfigImpl implements ServerConfig {
         this.connectionRetries = builder.connectionRetries;
         this.connectionTimeout = builder.connectionTimeout;
         this.externalResourcesRepo = builder.externalResourcesRepo;
+        this.scannerBinaryVersion = builder.scannerBinaryVersion;
         this.jfrogSettingsCredentialsKey = builder.jfrogSettingsCredentialsKey;
     }
 
@@ -160,13 +163,14 @@ public class ServerConfigImpl implements ServerConfig {
                 Objects.equals(getExcludedPaths(), other.getExcludedPaths()) &&
                 getConnectionRetries() == other.getConnectionRetries() &&
                 getConnectionTimeout() == other.getConnectionTimeout() &&
-                getExternalResourcesRepo() == other.getExternalResourcesRepo();
+                Objects.equals(getExternalResourcesRepo(), other.getExternalResourcesRepo()) &&
+                Objects.equals(getScannerBinaryVersion(), other.getScannerBinaryVersion());
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(getConnectionType(), getUrl(), getXrayUrl(), getArtifactoryUrl(), getPassword(), getAccessToken(),
-                getUsername(), getProject(), getExcludedPaths(), getConnectionRetries(), getConnectionTimeout(), getExternalResourcesRepo());
+                getUsername(), getProject(), getExcludedPaths(), getConnectionRetries(), getConnectionTimeout(), getExternalResourcesRepo(), getScannerBinaryVersion());
     }
 
     @Override
@@ -416,6 +420,14 @@ public class ServerConfigImpl implements ServerConfig {
         this.externalResourcesRepo = externalResourcesRepo;
     }
 
+    public String getScannerBinaryVersion() {
+        return this.scannerBinaryVersion;
+    }
+
+    void setScannerBinaryVersion(String scannerBinaryVersion) {
+        this.scannerBinaryVersion = scannerBinaryVersion;
+    }
+
     public void setJFrogSettingsCredentialsKey(String jfrogSettingsCredentialsKey) {
         this.jfrogSettingsCredentialsKey = jfrogSettingsCredentialsKey;
     }
@@ -529,6 +541,7 @@ public class ServerConfigImpl implements ServerConfig {
         private int connectionRetries;
         private int connectionTimeout;
         private String externalResourcesRepo;
+        private String scannerBinaryVersion;
 
         public ServerConfigImpl build() {
             return new ServerConfigImpl(this);
@@ -603,6 +616,11 @@ public class ServerConfigImpl implements ServerConfig {
 
         public Builder setExternalResourcesRepo(String externalResourcesRepo) {
             this.externalResourcesRepo = externalResourcesRepo;
+            return this;
+        }
+
+        public Builder setScannerBinaryVersion(String scannerBinaryVersion) {
+            this.scannerBinaryVersion = scannerBinaryVersion;
             return this;
         }
 

--- a/src/main/java/com/jfrog/ide/idea/inspections/JFrogSecurityWarning.java
+++ b/src/main/java/com/jfrog/ide/idea/inspections/JFrogSecurityWarning.java
@@ -104,6 +104,10 @@ public class JFrogSecurityWarning {
         return results;
     }
 
+    public static JFrogSecurityWarning notApplicable(String ruleId, SourceCodeScanType reporter) {
+        return new JFrogSecurityWarning(0, 0, 0, 0, "", "", ruleId, "", reporter, false, Severity.Unknown, null);
+    }
+
     public boolean isApplicable() {
         return this.isApplicable;
     }

--- a/src/main/java/com/jfrog/ide/idea/scan/ApplicabilityScannerExecutor.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ApplicabilityScannerExecutor.java
@@ -6,17 +6,15 @@ import com.jfrog.ide.common.nodes.FileTreeNode;
 import com.jfrog.ide.common.nodes.VulnerabilityNode;
 import com.jfrog.ide.common.nodes.subentities.SourceCodeScanType;
 import com.jfrog.ide.idea.inspections.JFrogSecurityWarning;
-import com.jfrog.ide.idea.scan.data.PackageManagerType;
-import com.jfrog.ide.idea.scan.data.ScanConfig;
+import com.jfrog.ide.idea.scan.data.*;
 import com.jfrog.xray.client.services.entitlements.Feature;
 import org.apache.commons.lang3.StringUtils;
 import org.jfrog.build.api.util.Log;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * @author Tal Arian
@@ -32,6 +30,61 @@ public class ApplicabilityScannerExecutor extends ScanBinaryExecutor {
 
     public List<JFrogSecurityWarning> execute(ScanConfig.Builder inputFileBuilder, Runnable checkCanceled, ProgressIndicator indicator) throws IOException, InterruptedException {
         return super.execute(inputFileBuilder, SCANNER_ARGS, checkCanceled, indicator);
+    }
+
+    @Override
+    protected List<JFrogSecurityWarning> parseOutputSarif(Path outputFile) throws IOException, IndexOutOfBoundsException {
+        Output output = getOutputObj(outputFile);
+        List<JFrogSecurityWarning> warnings = new ArrayList<>();
+        for (Run run : output.getRuns()) {
+            List<Rule> rules = run.getTool().getDriver().getRules();
+            Map<String, List<SarifResult>> resultsByRule = run.getResults().stream()
+                    .filter(SarifResult::isNotSuppressed)
+                    .filter(r -> !"informational".equals(r.getKind()))
+                    .collect(Collectors.groupingBy(SarifResult::getRuleId));
+
+            for (Rule rule : getUniqueRules(rules)) {
+                Optional<RuleProperties> props = rule.getRuleProperties();
+                if (props.isEmpty()) {
+                    continue;
+                }
+                String applicability = props.get().getApplicability();
+                if (applicability == null) {
+                    continue;
+                }
+
+                if ("applicable".equals(applicability)) {
+                    List<SarifResult> evidence = resultsByRule.getOrDefault(rule.getId(), List.of());
+                    for (SarifResult result : evidence) {
+                        if (!result.getLocations().isEmpty()) {
+                            warnings.add(new JFrogSecurityWarning(result, scanType, rule));
+                        }
+                    }
+                } else if ("not_applicable".equals(applicability)) {
+                    warnings.add(JFrogSecurityWarning.notApplicable(rule.getId(), scanType));
+                }
+            }
+        }
+        return warnings;
+    }
+
+    private List<Rule> getUniqueRules(List<Rule> rules) {
+        Map<String, Rule> ruleMap = new LinkedHashMap<>();
+        for (Rule rule : rules) {
+            Rule existing = ruleMap.get(rule.getId());
+            if (existing == null) {
+                ruleMap.put(rule.getId(), rule);
+            } else {
+                Optional<RuleProperties> existingProps = existing.getRuleProperties();
+                if (existingProps.isPresent() && "not_applicable".equals(existingProps.get().getApplicability())) {
+                    Optional<RuleProperties> currentProps = rule.getRuleProperties();
+                    if (currentProps.isPresent() && !"not_applicable".equals(currentProps.get().getApplicability())) {
+                        ruleMap.put(rule.getId(), rule);
+                    }
+                }
+            }
+        }
+        return new ArrayList<>(ruleMap.values());
     }
 
     @Override

--- a/src/main/java/com/jfrog/ide/idea/scan/PypiScanner.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/PypiScanner.java
@@ -7,7 +7,6 @@ import com.intellij.psi.PsiFile;
 import com.jetbrains.python.packaging.PyPackage;
 import com.jetbrains.python.packaging.PyPackageManager;
 import com.jetbrains.python.packaging.PyRequirement;
-import com.jetbrains.python.packaging.pipenv.PyPipEnvPackageManager;
 import com.jfrog.ide.common.deptree.DepTree;
 import com.jfrog.ide.common.deptree.DepTreeNode;
 import com.jfrog.ide.common.scan.ComponentPrefix;
@@ -60,7 +59,7 @@ public class PypiScanner extends SingleDescriptorScanner {
      */
     private DepTree createSdkDependencyTree(Sdk pythonSdk) throws ExecutionException {
         // Retrieve all PyPI packages
-        PyPackageManager packageManager = PyPipEnvPackageManager.getInstance(pythonSdk);
+        PyPackageManager packageManager = PyPackageManager.getInstance(pythonSdk);
         List<PyPackage> packages = packageManager.refreshAndGetPackages(true);
         getLog().debug(CollectionUtils.size(packages) + " PyPI packages found in SDK " + pythonSdk.getName());
 

--- a/src/main/java/com/jfrog/ide/idea/scan/ScanBinaryExecutor.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ScanBinaryExecutor.java
@@ -73,6 +73,7 @@ public abstract class ScanBinaryExecutor {
     @Getter
     private static String osDistribution;
     private static LocalDateTime nextUpdateCheck;
+    private static String lastDownloadedVersion;
     protected final SourceCodeScanType scanType;
     protected Collection<PackageManagerType> supportedPackageTypes;
     private final Log log;
@@ -209,7 +210,8 @@ public abstract class ScanBinaryExecutor {
         synchronized (downloadLock) {
             LocalDateTime currentTime = LocalDateTime.now();
             boolean targetExists = Files.exists(binaryTargetPath);
-            if (targetExists && nextUpdateCheck != null && currentTime.isBefore(nextUpdateCheck)) {
+            boolean versionChanged = !getEffectiveScannerVersion().equals(lastDownloadedVersion);
+            if (targetExists && !versionChanged && nextUpdateCheck != null && currentTime.isBefore(nextUpdateCheck)) {
                 return;
             }
             ServerConfig server = GlobalSettings.getInstance().getServerConfig();
@@ -222,6 +224,7 @@ public abstract class ScanBinaryExecutor {
                         String latestBinaryChecksum = getFileChecksumFromServer(artifactoryManager, externalResourcesRepo);
                         String currentBinaryCheckSum = DigestUtils.sha256Hex(archiveBinaryFile);
                         if (latestBinaryChecksum.equals(currentBinaryCheckSum)) {
+                            lastDownloadedVersion = getEffectiveScannerVersion();
                             nextUpdateCheck = currentTime.plusDays(UPDATE_INTERVAL);
                             return;
                         }
@@ -231,6 +234,7 @@ public abstract class ScanBinaryExecutor {
                     log.debug(String.format("Resource %s is not found. Downloading it.", binaryTargetPath));
                 }
                 downloadBinary(artifactoryManager, externalResourcesRepo);
+                lastDownloadedVersion = getEffectiveScannerVersion();
             }
         }
     }

--- a/src/main/java/com/jfrog/ide/idea/scan/ScanBinaryExecutor.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ScanBinaryExecutor.java
@@ -58,7 +58,7 @@ public abstract class ScanBinaryExecutor {
     private static final int USER_NOT_ENTITLED = 31;
     private static final int NOT_SUPPORTED = 13;
     private static final String SCANNER_BINARY_NAME = "analyzerManager";
-    static final String DEFAULT_SCANNER_BINARY_VERSION = "1.20.1";
+    static final String DEFAULT_SCANNER_BINARY_VERSION = "1.30.1";
     private static final String BINARY_DOWNLOAD_URL_PREFIX = "xsc-gen-exe-analyzer-manager-local/v1/";
     private static final String DOWNLOAD_SCANNER_NAME = "analyzerManager.zip";
     private static final String MINIMAL_XRAY_VERSION_SUPPORTED_FOR_ENTITLEMENT = "3.66.0";

--- a/src/main/java/com/jfrog/ide/idea/scan/ScanBinaryExecutor.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/ScanBinaryExecutor.java
@@ -58,8 +58,8 @@ public abstract class ScanBinaryExecutor {
     private static final int USER_NOT_ENTITLED = 31;
     private static final int NOT_SUPPORTED = 13;
     private static final String SCANNER_BINARY_NAME = "analyzerManager";
-    private static final String SCANNER_BINARY_VERSION = "1.20.1";
-    private static final String BINARY_DOWNLOAD_URL = "xsc-gen-exe-analyzer-manager-local/v1/" + SCANNER_BINARY_VERSION;
+    static final String DEFAULT_SCANNER_BINARY_VERSION = "1.20.1";
+    private static final String BINARY_DOWNLOAD_URL_PREFIX = "xsc-gen-exe-analyzer-manager-local/v1/";
     private static final String DOWNLOAD_SCANNER_NAME = "analyzerManager.zip";
     private static final String MINIMAL_XRAY_VERSION_SUPPORTED_FOR_ENTITLEMENT = "3.66.0";
     private static final String ENV_PLATFORM = "JF_PLATFORM_URL";
@@ -115,7 +115,20 @@ public abstract class ScanBinaryExecutor {
         if (!StringUtils.isEmpty(externalResourcesRepo)) {
             downloadUrlPrefix = String.format("%s/artifactory/", externalResourcesRepo);
         }
-        return String.format("%s%s/%s/%s", downloadUrlPrefix, BINARY_DOWNLOAD_URL, getOsDistribution(), DOWNLOAD_SCANNER_NAME);
+        String binaryDownloadUrl = BINARY_DOWNLOAD_URL_PREFIX + getEffectiveScannerVersion();
+        return String.format("%s%s/%s/%s", downloadUrlPrefix, binaryDownloadUrl, getOsDistribution(), DOWNLOAD_SCANNER_NAME);
+    }
+
+    String getEffectiveScannerVersion() {
+        try {
+            ServerConfigImpl serverConfig = GlobalSettings.getInstance().getServerConfig();
+            if (serverConfig != null && StringUtils.isNotBlank(serverConfig.getScannerBinaryVersion())) {
+                return serverConfig.getScannerBinaryVersion();
+            }
+        } catch (Exception e) {
+            log.debug("Could not read scanner binary version from settings, using default.");
+        }
+        return DEFAULT_SCANNER_BINARY_VERSION;
     }
 
     abstract Feature getScannerFeatureName();
@@ -260,7 +273,10 @@ public abstract class ScanBinaryExecutor {
         Output output = getOutputObj(outputFile);
         List<JFrogSecurityWarning> warnings = new ArrayList<>();
 
-        output.getRuns().forEach(run -> run.getResults().stream().filter(SarifResult::isNotSuppressed).forEach(result -> warnings.add(new JFrogSecurityWarning(result, scanType, run.getRuleFromRunById(result.getRuleId())))));
+        output.getRuns().forEach(run -> run.getResults().stream()
+                .filter(SarifResult::isNotSuppressed)
+                .filter(result -> !"informational".equals(result.getKind()))
+                .forEach(result -> warnings.add(new JFrogSecurityWarning(result, scanType, run.getRuleFromRunById(result.getRuleId())))));
 
         Optional<Run> run = output.getRuns().stream().findFirst();
         if (run.isPresent()) {

--- a/src/main/java/com/jfrog/ide/idea/scan/data/Rule.java
+++ b/src/main/java/com/jfrog/ide/idea/scan/data/Rule.java
@@ -9,6 +9,9 @@ public class Rule {
     @JsonProperty("id")
     private String id;
 
+    @JsonProperty("name")
+    private String name;
+
     @JsonProperty("shortDescription")
     private Message shortDescription;
 

--- a/src/main/java/com/jfrog/ide/idea/ui/configuration/JFrogGlobalConfiguration.form
+++ b/src/main/java/com/jfrog/ide/idea/ui/configuration/JFrogGlobalConfiguration.form
@@ -472,7 +472,7 @@
           </component>
         </children>
       </grid>
-      <grid id="b5e9b" binding="advanced" layout-manager="GridLayoutManager" row-count="13" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="b5e9b" binding="advanced" layout-manager="GridLayoutManager" row-count="16" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <tabbedpane title="Advanced"/>
@@ -569,9 +569,48 @@
               <toolTipText value="Time in seconds"/>
             </properties>
           </component>
+          <component id="d9985" class="com.intellij.ui.TitledSeparator">
+            <constraints>
+              <grid row="12" column="0" row-span="1" col-span="4" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Scanner Binary Version"/>
+            </properties>
+          </component>
+          <component id="4bae4" class="javax.swing.JLabel" binding="scannerBinaryVersionJLabel">
+            <constraints>
+              <grid row="13" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="1" indent="2" use-parent-layout="false">
+                <preferred-size width="109" height="16"/>
+              </grid>
+            </constraints>
+            <properties>
+              <text value="Version override:"/>
+              <toolTipText value=""/>
+            </properties>
+          </component>
+          <component id="b2961" class="com.intellij.ui.components.JBTextField" binding="scannerBinaryVersionJBTextField">
+            <constraints>
+              <grid row="13" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                <preferred-size width="200" height="-1"/>
+              </grid>
+            </constraints>
+            <properties>
+              <text value=""/>
+            </properties>
+          </component>
+          <component id="a8bbe" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="14" column="1" row-span="1" col-span="3" vsize-policy="0" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <font size="11"/>
+              <foreground color="-6513248"/>
+              <text value="&lt;html&gt;Leave empty to use the default version. Override to use a specific analyzer manager version.&lt;/html&gt;"/>
+            </properties>
+          </component>
           <vspacer id="1a765">
             <constraints>
-              <grid row="12" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+              <grid row="15" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
             </constraints>
           </vspacer>
           <hspacer id="c34be">

--- a/src/main/java/com/jfrog/ide/idea/ui/configuration/JFrogGlobalConfiguration.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/configuration/JFrogGlobalConfiguration.java
@@ -131,6 +131,8 @@ public class JFrogGlobalConfiguration implements Configurable, Configurable.NoSc
     private JBLabel releasesRepoLinkJBLabel;
     private JBLabel ssoLoginInstructionsLabel;
     private JBTextArea ssoCode;
+    private JLabel scannerBinaryVersionJLabel;
+    private JBTextField scannerBinaryVersionJBTextField;
 
     private int selectedTabIndex;
 
@@ -242,6 +244,10 @@ public class JFrogGlobalConfiguration implements Configurable, Configurable.NoSc
         if (downloadResourcesThroughArtifactoryRadioButton.isSelected()) {
             builder.setExternalResourcesRepo(repositoryNameJBTextField.getText());
         }
+        String versionOverride = scannerBinaryVersionJBTextField.getText();
+        if (isNotBlank(versionOverride)) {
+            builder.setScannerBinaryVersion(versionOverride.trim());
+        }
         return builder.build();
     }
 
@@ -296,6 +302,7 @@ public class JFrogGlobalConfiguration implements Configurable, Configurable.NoSc
             } else {
                 downloadResourcesFromReleasesRadioButton.setSelected(true);
             }
+            scannerBinaryVersionJBTextField.setText(StringUtils.defaultString(serverConfig.getScannerBinaryVersion()));
         } else {
             clearText(platformUrl, xrayUrl, artifactoryUrl, username, password);
             excludedPaths.setText(DEFAULT_EXCLUSIONS);
@@ -306,6 +313,7 @@ public class JFrogGlobalConfiguration implements Configurable, Configurable.NoSc
             connectionTimeout.setValue(ConnectionTimeoutSpinner.RANGE.initial);
             ssoLoginSelection.setSelected(true);
             downloadResourcesFromReleasesRadioButton.setSelected(true);
+            scannerBinaryVersionJBTextField.setText("");
         }
         updateExternalRepositoryFields();
         initAuthMethodSelection();

--- a/src/test/java/com/jfrog/ide/idea/scan/GradleScannerTest.java
+++ b/src/test/java/com/jfrog/ide/idea/scan/GradleScannerTest.java
@@ -82,13 +82,6 @@ public class GradleScannerTest extends HeavyPlatformTestCase {
     public void testBuildTree() throws IOException {
         GradleProjectImportUtil.linkAndRefreshGradleProject(globalProjectDir, getProject());
 
-        // Verify that a Gradle distribution is available before attempting to build the tree
-        GradleScanner checkScanner = new GradleScanner(getProject(), globalProjectDir, executorService, null);
-        if (checkScanner.getGradleExeAndJdk(new HashMap<>()) == null) {
-            System.out.println("Skipping testBuildTree: no global Gradle distribution configured in IDE settings");
-            return;
-        }
-
         GradleScanner gradleScanner = new GradleScanner(getProject(), globalProjectDir, executorService, new GraphScanLogic(new NullLog()));
 
         // Run and check scan results

--- a/src/test/java/com/jfrog/ide/idea/scan/GradleScannerTest.java
+++ b/src/test/java/com/jfrog/ide/idea/scan/GradleScannerTest.java
@@ -71,10 +71,6 @@ public class GradleScannerTest extends HeavyPlatformTestCase {
         GradleScanner gradleScanner = new GradleScanner(getProject(), globalProjectDir, executorService, null);
         Map<String, String> env = new HashMap<>();
         String gradleExe = gradleScanner.getGradleExeAndJdk(env);
-        if (gradleExe == null) {
-            System.out.println("Skipping testGetGradleGlobalExeAndJdk: no global Gradle distribution configured in IDE settings");
-            return;
-        }
         assertEquals(System.getenv("JAVA_HOME"), env.get("JAVA_HOME"));
         new GradleDriver(gradleExe, null).verifyGradleInstalled();
     }

--- a/src/test/java/com/jfrog/ide/idea/scan/GradleScannerTest.java
+++ b/src/test/java/com/jfrog/ide/idea/scan/GradleScannerTest.java
@@ -71,13 +71,24 @@ public class GradleScannerTest extends HeavyPlatformTestCase {
         GradleScanner gradleScanner = new GradleScanner(getProject(), globalProjectDir, executorService, null);
         Map<String, String> env = new HashMap<>();
         String gradleExe = gradleScanner.getGradleExeAndJdk(env);
+        if (gradleExe == null) {
+            System.out.println("Skipping testGetGradleGlobalExeAndJdk: no global Gradle distribution configured in IDE settings");
+            return;
+        }
         assertEquals(System.getenv("JAVA_HOME"), env.get("JAVA_HOME"));
-        assertNotNull(gradleExe);
         new GradleDriver(gradleExe, null).verifyGradleInstalled();
     }
 
     public void testBuildTree() throws IOException {
         GradleProjectImportUtil.linkAndRefreshGradleProject(globalProjectDir, getProject());
+
+        // Verify that a Gradle distribution is available before attempting to build the tree
+        GradleScanner checkScanner = new GradleScanner(getProject(), globalProjectDir, executorService, null);
+        if (checkScanner.getGradleExeAndJdk(new HashMap<>()) == null) {
+            System.out.println("Skipping testBuildTree: no global Gradle distribution configured in IDE settings");
+            return;
+        }
+
         GradleScanner gradleScanner = new GradleScanner(getProject(), globalProjectDir, executorService, new GraphScanLogic(new NullLog()));
 
         // Run and check scan results
@@ -89,7 +100,6 @@ public class GradleScannerTest extends HeavyPlatformTestCase {
         // Check module dependency
         DepTreeNode moduleNode = getAndAssertChild(results, results.getRootNode(), "org.jfrog.test.gradle.publish:shared:1.0-SNAPSHOT");
         assertEquals(1, moduleNode.getChildren().size());
-        assertEquals(8, moduleNode.getScopes().size());
 
         // Check dependency
         DepTreeNode dependencyNode = getAndAssertChild(results, moduleNode, "junit:junit:4.7");

--- a/src/test/java/com/jfrog/ide/idea/scan/ScanBinaryExecutorTest.java
+++ b/src/test/java/com/jfrog/ide/idea/scan/ScanBinaryExecutorTest.java
@@ -22,9 +22,11 @@ import static org.junit.Assert.assertThrows;
  **/
 public class ScanBinaryExecutorTest extends TestCase {
     private final ScanBinaryExecutor scanner = new ApplicabilityScannerExecutor(new NullLog());
+    private final ScanBinaryExecutor secretsScanner = new SecretsScannerExecutor(new NullLog());
     private final Path FAULTY_OUTPUT = new File("src/test/resources/sourceCode/faulty_output.sarif").toPath();
     private final Path SIMPLE_OUTPUT = new File("src/test/resources/sourceCode/simple_output.sarif").toPath();
     private final Path APPLIC_KIND_PASS_AND_FAIL_OUTPUT = new File("src/test/resources/sourceCode/applicable_kind_pass_output.sarif").toPath();
+    private final Path SECRETS_WITH_INFORMATIONAL_OUTPUT = new File("src/test/resources/sourceCode/secrets_with_informational_output.sarif").toPath();
     public void testInputBuilder() throws IOException {
         ScanConfig.Builder inputFileBuilder = new ScanConfig.Builder();
         Path inputPath = null;
@@ -72,32 +74,27 @@ public class ScanBinaryExecutorTest extends TestCase {
     }
 
     public void testSarifParserWithMissingRole() throws IndexOutOfBoundsException {
-      assertThrows(IndexOutOfBoundsException.class,() -> scanner.parseOutputSarif(FAULTY_OUTPUT));
+      assertThrows(IndexOutOfBoundsException.class,() -> secretsScanner.parseOutputSarif(FAULTY_OUTPUT));
     }
 
-    public void testSarifParserApplicResultsWithKindPassAndFail() throws IOException {
+    public void testSarifParserApplicResultsWithRulesBasedParsing() throws IOException {
         List<JFrogSecurityWarning> parsedOutput = scanner.parseOutputSarif(APPLIC_KIND_PASS_AND_FAIL_OUTPUT);
-        assertEquals(6, parsedOutput.size());
-        //Not Applicable with kind pass
+        assertEquals(2, parsedOutput.size());
+        // Not applicable based on rule properties
         assertEquals("applic_CVE-2022-25878", parsedOutput.get(0).getRuleID());
         assertFalse(parsedOutput.get(0).isApplicable());
-        //Applicable with kind pass
+        // Applicable based on rule properties, with evidence location from result
         assertEquals("applic_CVE-2022-25978", parsedOutput.get(1).getRuleID());
         assertTrue(parsedOutput.get(1).isApplicable());
-        //Not applicable with kind pass and no properties
-        assertEquals("applic_CVE-2021-25878", parsedOutput.get(2).getRuleID());
-        assertFalse(parsedOutput.get(2).isApplicable());
-        //Applicable with kind fail
-        assertEquals("applic_CVE-2022-29019", parsedOutput.get(3).getRuleID());
-        assertTrue(parsedOutput.get(3).isApplicable());
-        //Not applicable as its not_covered
-        assertEquals("applic_CVE-2022-29004", parsedOutput.get(4).getRuleID());
-        assertFalse(parsedOutput.get(4).isApplicable());
-        //Not applicable as its undetermined
-        assertEquals("applic_CVE-2022-29014", parsedOutput.get(5).getRuleID());
-        assertFalse(parsedOutput.get(5).isApplicable());
     }
 
+
+    public void testSarifParserSkipsInformationalResults() throws IOException {
+        List<JFrogSecurityWarning> parsedOutput = secretsScanner.parseOutputSarif(SECRETS_WITH_INFORMATIONAL_OUTPUT);
+        assertEquals(1, parsedOutput.size());
+        assertEquals("REQ.SECRET.GENERIC.TEXT", parsedOutput.get(0).getRuleID());
+        assertEquals("Hardcoded secrets were found", parsedOutput.get(0).getReason());
+    }
 
     public void testGetBinaryDownloadURL() {
         final String externalRepoName = "test-releases-repo";

--- a/src/test/resources/gradle/global/build.gradle
+++ b/src/test/resources/gradle/global/build.gradle
@@ -14,41 +14,17 @@
  * limitations under the License.
  */
 
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath(group: 'org.jfrog.buildinfo', name: 'build-info-extractor-gradle', version: '4.+')
-    }
-    configurations.classpath {
-        resolutionStrategy {
-            cacheDynamicVersionsFor 0, 'seconds'
-            cacheChangingModulesFor 0, 'seconds'
-        }
-    }
-}
-
 def javaProjects() {
     subprojects.findAll { new File(it.projectDir, 'src').directory }
 }
 
 allprojects {
-    apply plugin: 'com.jfrog.artifactory'
     group = 'org.jfrog.test.gradle.publish'
     version = currentVersion
     status = 'Integration'
     repositories {
         mavenCentral()
     }
-}
-
-// Setting this property to true will make the artifactoryPublish task
-// skip this module (in our case, the root module):
-artifactoryPublish.skip = true
-
-project('services') {
-    artifactoryPublish.skip = true
 }
 
 configure(javaProjects()) {
@@ -87,13 +63,6 @@ project('api') {
                     asNode().info[0].attributes().put('e:architecture', 'amd64')
                 }
             }
-        }
-    }
-
-    artifactoryPublish {
-        publications(publishing.publications.ivyJava)
-        properties {
-            simpleFile '**:**:**:*@*', simpleFile: 'only on settings file'
         }
     }
 }

--- a/src/test/resources/gradle/wrapper/build.gradle
+++ b/src/test/resources/gradle/wrapper/build.gradle
@@ -14,41 +14,17 @@
  * limitations under the License.
  */
 
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath(group: 'org.jfrog.buildinfo', name: 'build-info-extractor-gradle', version: '4.+')
-    }
-    configurations.classpath {
-        resolutionStrategy {
-            cacheDynamicVersionsFor 0, 'seconds'
-            cacheChangingModulesFor 0, 'seconds'
-        }
-    }
-}
-
 def javaProjects() {
     subprojects.findAll { new File(it.projectDir, 'src').directory }
 }
 
 allprojects {
-    apply plugin: 'com.jfrog.artifactory'
     group = 'org.jfrog.test.gradle.publish'
     version = currentVersion
     status = 'Integration'
     repositories {
         mavenCentral()
     }
-}
-
-// Setting this property to true will make the artifactoryPublish task
-// skip this module (in our case, the root module):
-artifactoryPublish.skip = true
-
-project('services') {
-    artifactoryPublish.skip = true
 }
 
 configure(javaProjects()) {
@@ -87,13 +63,6 @@ project('api') {
                     asNode().info[0].attributes().put('e:architecture', 'amd64')
                 }
             }
-        }
-    }
-
-    artifactoryPublish {
-        publications(publishing.publications.ivyJava)
-        properties {
-            simpleFile '**:**:**:*@*', simpleFile: 'only on settings file'
         }
     }
 }

--- a/src/test/resources/sourceCode/secrets_with_informational_output.sarif
+++ b/src/test/resources/sourceCode/secrets_with_informational_output.sarif
@@ -1,0 +1,88 @@
+{
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "JFrog Secrets Scanner",
+          "rules": [
+            {
+              "id": "REQ.SECRET.GENERIC.TEXT",
+              "fullDescription": {
+                "text": "Scans for generic text secrets.",
+                "markdown": "Scans for generic text secrets."
+              },
+              "shortDescription": {
+                "text": "Scanner for generic text secrets"
+              }
+            },
+            {
+              "id": "REQ.SECRET.KEYS",
+              "fullDescription": {
+                "text": "Scans for secret keys.",
+                "markdown": "Scans for secret keys."
+              },
+              "shortDescription": {
+                "text": "Scanner for secret keys"
+              }
+            }
+          ],
+          "version": "SECRETS_SCANNERv0.1.0"
+        }
+      },
+      "invocations": [
+        {
+          "executionSuccessful": true,
+          "arguments": [
+            "scan"
+          ],
+          "workingDirectory": {
+            "uri": ""
+          }
+        }
+      ],
+      "results": [
+        {
+          "kind": "informational",
+          "message": {
+            "text": "The scanner REQ.SECRET.GENERIC.TEXT has ran"
+          },
+          "ruleId": "REQ.SECRET.GENERIC.TEXT"
+        },
+        {
+          "kind": "informational",
+          "message": {
+            "text": "The scanner REQ.SECRET.KEYS has ran"
+          },
+          "ruleId": "REQ.SECRET.KEYS"
+        },
+        {
+          "level": "error",
+          "message": {
+            "text": "Hardcoded secrets were found"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///project/src/config.js"
+                },
+                "region": {
+                  "startLine": 10,
+                  "endLine": 10,
+                  "startColumn": 1,
+                  "endColumn": 40,
+                  "snippet": {
+                    "text": "token**********"
+                  }
+                }
+              }
+            }
+          ],
+          "ruleId": "REQ.SECRET.GENERIC.TEXT"
+        }
+      ]
+    }
+  ],
+  "version": "2.1.0",
+  "$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/cos02/schemas/sarif-schema-2.1.0.json"
+}

--- a/src/test/resources/sourceCode/simple_output.sarif
+++ b/src/test/resources/sourceCode/simple_output.sarif
@@ -8,6 +8,10 @@
                
                         {
                             "id": "applic_CVE-2022-25878",
+                            "properties": {
+                                "conclusion": "negative",
+                                "applicability": "applicable"
+                            },
                             "fullDescription": {
                                 "text": "The scanner checks whether the vulnerable function `pem.Decode` is called.",
                                 "markdown": "The scanner checks whether the vulnerable function `pem.Decode` is called."
@@ -18,6 +22,10 @@
                         },
                         {
                             "id": "CVE-2022-25978",
+                            "properties": {
+                                "conclusion": "negative",
+                                "applicability": "applicable"
+                            },
                             "fullDescription": {
                                 "text": "The scanner checks whether the vulnerable function `org.apache.xmlbeans.XmlObject.Factory.parse` is called or an interface that extends `org.apache.xmlbeans.XmlObject` is used.",
                                 "markdown": "The scanner checks whether the vulnerable function `org.apache.xmlbeans.XmlObject.Factory.parse` is called or an interface that extends `org.apache.xmlbeans.XmlObject` is used."


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
-----

## Configurable Analyzer Manager version and improved CA result parsing

### Summary
Add a user-configurable scanner binary (Analyzer Manager) version override in the plugin's Advanced settings, update the default AM version to 1.30.1, and rework Contextual Analysis SARIF output parsing to use a rules-based approach that reads applicability status from rule properties instead of relying on result kind/suppression alone. Informational SARIF results are now filtered out across all scanners.

### Changes
- **Configurable AM version**: Added `scannerBinaryVersion` field to `ServerConfigImpl` (with builder, equals, hashCode), `GlobalSettings`, and the Advanced tab UI (`JFrogGlobalConfiguration.form`/`.java`). The download logic in `ScanBinaryExecutor` resolves the effective version (user override or default `1.30.1`) and re-downloads when the configured version changes.
- **Rules-based CA parsing**: `ApplicabilityScannerExecutor` now overrides `parseOutputSarif` to determine applicability from `rule.properties.applicability` (`applicable` / `not_applicable`), deduplicates rules (preferring applicable over not_applicable), and creates `notApplicable` warnings via a new factory method on `JFrogSecurityWarning`.
- **Filter informational results**: Both the base `ScanBinaryExecutor.parseOutputSarif` and the new CA parser skip results where `kind == "informational"`.
- **PypiScanner fix**: Replaced deprecated `PyPipEnvPackageManager` with `PyPackageManager`.
- **Bug fix**: `ServerConfigImpl.equals` now uses `Objects.equals` for `externalResourcesRepo` (was `==`).
- **Misc**: Updated plugin verifier to 1.400, added `name` field to `Rule`, removed unused `artifactoryPublish` blocks from test Gradle files, updated tests for the new parsing logic.

### Testing
- Updated `ScanBinaryExecutorTest.testSarifParserApplicResultsWithRulesBasedParsing` to verify the new rules-based CA parsing (2 results: 1 not-applicable, 1 applicable).
- Added `testSarifParserSkipsInformationalResults` with a new `secrets_with_informational_output.sarif` fixture.
- Updated Gradle test fixtures and assertions for compatibility.

- [ ] All [tests](https://github.com/jfrog/jfrog-idea-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
