### PR TITLE
Update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,10 +67,13 @@ repositories {
     maven {
         url "https://releases.jfrog.io/artifactory/oss-snapshots"
     }
+    maven {
+        url "https://cache-redirector.jetbrains.com/intellij-dependencies"
+    }
 }
 
-def buildInfoVersion = '2.41.13'
-def idePluginsCommonVersion = '2.3.7'
+def buildInfoVersion = '2.43.6'
+def idePluginsCommonVersion = '2.4.4'
 
 dependencies {
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.15.2'

--- a/build.gradle
+++ b/build.gradle
@@ -74,13 +74,15 @@ repositories {
 
 def buildInfoVersion = '2.43.6'
 def idePluginsCommonVersion = '2.4.4'
+// Updated to 2.17.3 for security fixes - compatible with Java 8+
+def jacksonVersion = '2.17.3'
 
 dependencies {
-    implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.15.2'
+    implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: jacksonVersion
     implementation group: 'org.jfrog.buildinfo', name: 'build-info-extractor', version: buildInfoVersion
     implementation group: 'com.jfrog.ide', name: 'ide-plugins-common', version: idePluginsCommonVersion
     implementation group: 'org.jfrog.buildinfo', name: 'build-info-client', version: buildInfoVersion
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.15.3'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: jacksonVersion
     implementation group: 'org.jfrog.buildinfo', name: 'build-info-api', version: buildInfoVersion
     implementation group: 'com.jfrog.xray.client', name: 'xray-client-java', version: '0.14.1'
     implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'

--- a/src/main/java/com/jfrog/ide/idea/configuration/ServerConfigImpl.java
+++ b/src/main/java/com/jfrog/ide/idea/configuration/ServerConfigImpl.java
@@ -44,6 +44,7 @@ import java.net.InetSocketAddress;
 import java.net.PasswordAuthentication;
 import java.net.Proxy;
 import java.net.URI;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
 
@@ -494,7 +495,7 @@ public class ServerConfigImpl implements ServerConfig {
      * @return true if connection details loaded from JFrog CLI default server.
      */
     public boolean readConnectionDetailsFromJfrogCli() throws IOException {
-        JfrogCliDriver driver = new JfrogCliDriver(EnvironmentUtil.getEnvironmentMap());
+        JfrogCliDriver driver = new JfrogCliDriver(new HashMap<>(EnvironmentUtil.getEnvironmentMap()), null);
         if (!driver.isJfrogCliInstalled()) {
             return false;
         }

--- a/src/main/java/com/jfrog/ide/idea/ui/webview/WebviewObjectConverter.java
+++ b/src/main/java/com/jfrog/ide/idea/ui/webview/WebviewObjectConverter.java
@@ -62,7 +62,7 @@ public class WebviewObjectConverter {
     public static IssuePage convertSastIssueToSastIssuePage(SastIssueNode sastIssueNode) {
         return new SastIssuePage(convertFileIssueToIssuePage(sastIssueNode))
                 .setAnalysisSteps(convertCodeFlowsToLocations(sastIssueNode.getCodeFlows()))
-                .setRuleID(sastIssueNode.getRuleID());
+                .setRuleID(sastIssueNode.getRuleId());
     }
 
     private static Location[] convertCodeFlowsToLocations(FindingInfo[][] codeFlows) {

--- a/src/test/java/com/jfrog/ide/idea/configuration/ConnectionDetailsFromCliTest.java
+++ b/src/test/java/com/jfrog/ide/idea/configuration/ConnectionDetailsFromCliTest.java
@@ -71,8 +71,8 @@ public class ConnectionDetailsFromCliTest {
 
             // Config JFrog CLI
             if (cliParameters != null) {
-                JfrogCliDriver jfrogCliDriver = new JfrogCliDriver(envVars);
-                jfrogCliDriver.runCommand(null, cliParameters, new ArrayList<>(), null);
+                JfrogCliDriver jfrogCliDriver = new JfrogCliDriver(envVars, null);
+                jfrogCliDriver.runCommand(null, envVars, cliParameters, new ArrayList<>(), null, null);
             }
 
             // Check results


### PR DESCRIPTION
## `chore(deps): bump JFrog libraries and Jackson; align CLI driver API`

## Summary
This change updates Gradle dependencies (build-info extractor, ide-plugins-common, and Jackson), adds the JetBrains cache-redirector Maven repository for IDE-related artifacts, and adjusts call sites for `JfrogCliDriver` and SAST rule ID accessors to match the newer libraries.

## Changes
- **`build.gradle`**: Add `https://cache-redirector.jetbrains.com/intellij-dependencies`; bump `buildInfoVersion` (2.41.13 → 2.43.6), `idePluginsCommonVersion` (2.3.7 → 2.4.4); align `jackson-dataformat-yaml` and `jackson-databind` on Jackson **2.17.3** (single `jacksonVersion` variable).
- **`ServerConfigImpl.java`**: Construct `JfrogCliDriver` with a defensive copy of the environment map and the new constructor arity (`null` second argument).
- **`WebviewObjectConverter.java`**: Use `getRuleId()` instead of deprecated/removed `getRuleID()`.
- **`ConnectionDetailsFromCliTest.java`**: Update `JfrogCliDriver` construction and `runCommand(...)` to the new method signature (including passing `envVars` into `runCommand`).
