### PR TITLE
Fix GlobalSettings crash when JFrog CLI is not installed (XRAY-145646)

### DIFF
--- a/src/main/java/com/jfrog/ide/idea/configuration/ServerConfigImpl.java
+++ b/src/main/java/com/jfrog/ide/idea/configuration/ServerConfigImpl.java
@@ -34,6 +34,7 @@ import com.jfrog.ide.idea.ui.configuration.ConnectionRetriesSpinner;
 import com.jfrog.ide.idea.ui.configuration.ConnectionTimeoutSpinner;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.Strings;
+import org.jfrog.build.api.util.NullLog;
 import org.jfrog.build.client.ProxyConfiguration;
 
 import javax.annotation.CheckForNull;
@@ -498,7 +499,7 @@ public class ServerConfigImpl implements ServerConfig {
      * @return true if connection details loaded from JFrog CLI default server.
      */
     public boolean readConnectionDetailsFromJfrogCli() throws IOException {
-        JfrogCliDriver driver = new JfrogCliDriver(new HashMap<>(EnvironmentUtil.getEnvironmentMap()), null);
+        JfrogCliDriver driver = new JfrogCliDriver(new HashMap<>(EnvironmentUtil.getEnvironmentMap()), new NullLog());
         if (!driver.isJfrogCliInstalled()) {
             return false;
         }

--- a/src/test/java/com/jfrog/ide/idea/configuration/ConfigurationTest.java
+++ b/src/test/java/com/jfrog/ide/idea/configuration/ConfigurationTest.java
@@ -3,8 +3,15 @@ package com.jfrog.ide.idea.configuration;
 import com.intellij.credentialStore.Credentials;
 import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase;
 import com.intellij.util.EnvironmentUtil;
+import org.apache.commons.io.FileUtils;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
 
 import static com.jfrog.ide.idea.configuration.ServerConfigImpl.*;
 
@@ -163,6 +170,22 @@ public class ConfigurationTest extends LightJavaCodeInsightFixtureTestCase {
             ServerConfigImpl actualServerConfig = globalSettings.getServerConfig();
             actualServerConfig.readMissingConfFromEnv();
             assertEquals("releases-test", actualServerConfig.getExternalResourcesRepo());
+        }
+    }
+
+    /**
+     * XRAY-145646: when jf is not on PATH, isJfrogCliInstalled() logs the failure and must not NPE.
+     */
+    public void testReadConnectionDetailsFromJfrogCliWhenCliNotInstalled() throws IOException {
+        Path emptyPath = Files.createTempDirectory("noJfrogCliOnPath");
+        try (MockedStatic<EnvironmentUtil> mockController = Mockito.mockStatic(EnvironmentUtil.class)) {
+            Map<String, String> envVars = new HashMap<>(System.getenv());
+            envVars.put("PATH", emptyPath.toAbsolutePath().toString());
+            mockController.when(EnvironmentUtil::getEnvironmentMap).thenReturn(envVars);
+
+            assertFalse(new ServerConfigImpl().readConnectionDetailsFromJfrogCli());
+        } finally {
+            FileUtils.forceDelete(emptyPath.toFile());
         }
     }
 

--- a/src/test/java/com/jfrog/ide/idea/configuration/ConfigurationTest.java
+++ b/src/test/java/com/jfrog/ide/idea/configuration/ConfigurationTest.java
@@ -3,13 +3,13 @@ package com.jfrog.ide.idea.configuration;
 import com.intellij.credentialStore.Credentials;
 import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase;
 import com.intellij.util.EnvironmentUtil;
-import org.apache.commons.io.FileUtils;
+import com.jfrog.ide.common.configuration.JfrogCliDriver;
+import org.jfrog.build.api.util.Log;
+import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -174,18 +174,24 @@ public class ConfigurationTest extends LightJavaCodeInsightFixtureTestCase {
     }
 
     /**
-     * XRAY-145646: when jf is not on PATH, isJfrogCliInstalled() logs the failure and must not NPE.
+     * XRAY-145646: when jf is not installed, readConnectionDetailsFromJfrogCli must return false
+     * without NPE. NullLog must be passed to JfrogCliDriver (regression: null log NPEs in
+     * isJfrogCliInstalled). mockConstruction is used because CommandExecutor merges
+     * System.getenv() and appends /usr/local/bin on Unix, so PATH isolation is unreliable in CI.
      */
     public void testReadConnectionDetailsFromJfrogCliWhenCliNotInstalled() throws IOException {
-        Path emptyPath = Files.createTempDirectory("noJfrogCliOnPath");
-        try (MockedStatic<EnvironmentUtil> mockController = Mockito.mockStatic(EnvironmentUtil.class)) {
-            Map<String, String> envVars = new HashMap<>(System.getenv());
-            envVars.put("PATH", emptyPath.toAbsolutePath().toString());
-            mockController.when(EnvironmentUtil::getEnvironmentMap).thenReturn(envVars);
+        try (MockedStatic<EnvironmentUtil> mockController = Mockito.mockStatic(EnvironmentUtil.class);
+             MockedConstruction<JfrogCliDriver> driverConstruction = Mockito.mockConstruction(
+                     JfrogCliDriver.class,
+                     (mock, context) -> {
+                         assertNotNull(context.arguments().get(1));
+                         assertTrue(context.arguments().get(1) instanceof Log);
+                         Mockito.when(mock.isJfrogCliInstalled()).thenReturn(false);
+                     })) {
+            mockController.when(EnvironmentUtil::getEnvironmentMap).thenReturn(new HashMap<>());
 
             assertFalse(new ServerConfigImpl().readConnectionDetailsFromJfrogCli());
-        } finally {
-            FileUtils.forceDelete(emptyPath.toFile());
+            assertEquals(1, driverConstruction.constructed().size());
         }
     }
 

--- a/src/test/java/com/jfrog/ide/idea/configuration/ConfigurationTest.java
+++ b/src/test/java/com/jfrog/ide/idea/configuration/ConfigurationTest.java
@@ -173,12 +173,7 @@ public class ConfigurationTest extends LightJavaCodeInsightFixtureTestCase {
         }
     }
 
-    /**
-     * XRAY-145646: when jf is not installed, readConnectionDetailsFromJfrogCli must return false
-     * without NPE. NullLog must be passed to JfrogCliDriver (regression: null log NPEs in
-     * isJfrogCliInstalled). mockConstruction is used because CommandExecutor merges
-     * System.getenv() and appends /usr/local/bin on Unix, so PATH isolation is unreliable in CI.
-     */
+    /** XRAY-145646: CLI not installed must return false without NPE when Log is null-safe. */
     public void testReadConnectionDetailsFromJfrogCliWhenCliNotInstalled() throws IOException {
         try (MockedStatic<EnvironmentUtil> mockController = Mockito.mockStatic(EnvironmentUtil.class);
              MockedConstruction<JfrogCliDriver> driverConstruction = Mockito.mockConstruction(

--- a/src/test/java/com/jfrog/ide/idea/configuration/ConnectionDetailsFromCliTest.java
+++ b/src/test/java/com/jfrog/ide/idea/configuration/ConnectionDetailsFromCliTest.java
@@ -2,6 +2,7 @@ package com.jfrog.ide.idea.configuration;
 
 import com.intellij.util.EnvironmentUtil;
 import com.jfrog.ide.common.configuration.JfrogCliDriver;
+import org.jfrog.build.api.util.NullLog;
 import org.apache.commons.io.FileUtils;
 import org.gradle.internal.impldep.org.junit.Assert;
 import org.junit.Test;
@@ -71,7 +72,7 @@ public class ConnectionDetailsFromCliTest {
 
             // Config JFrog CLI
             if (cliParameters != null) {
-                JfrogCliDriver jfrogCliDriver = new JfrogCliDriver(envVars, null);
+                JfrogCliDriver jfrogCliDriver = new JfrogCliDriver(envVars, new NullLog());
                 jfrogCliDriver.runCommand(null, envVars, cliParameters, new ArrayList<>(), null, null);
             }
 


### PR DESCRIPTION
## Summary

Fixes **XRAY-145646** — IntelliJ plugin 2.9.0 fails to start on Windows with:

```
PluginException: Cannot init component state (GlobalSettings)
Caused by: NullPointerException: Cannot invoke Log.error() because "this.log" is null
  at JfrogCliDriver.runVersion → isJfrogCliInstalled
```

**Root cause:** `ide-plugins-common` 2.4.x (#525) changed `JfrogCliDriver(Map, String path)` to `JfrogCliDriver(Map, Log)`. `ServerConfigImpl.readConnectionDetailsFromJfrogCli()` still passed `null` as the second argument — previously the CLI path, now the `Log`. When `jf` is not on PATH (common on Windows), `isJfrogCliInstalled()` calls `log.error()` and NPEs during `GlobalSettings` init.

**Fix:** Pass `new NullLog()` instead of `null` when constructing `JfrogCliDriver`.

## Test plan

- [x] Reproduced NPE on Windows VM without `jf` on PATH (broken 2.9.0 build)
- [x] Verified fixed build: IntelliJ starts, Global Configuration saves and persists across restart
- [x] `ConnectionDetailsFromCliTest` updated and passes


Made with [Cursor](https://cursor.com)